### PR TITLE
Add intentionally failing Jest test (closes #43)

### DIFF
--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -54,6 +54,7 @@ describe('App Component', () => {
     expect(screen.getByTestId('main-navigation')).toBeInTheDocument();
     expect(screen.getByTestId('logo-link')).toBeInTheDocument();
     expect(screen.getByTestId('logo-image')).toBeInTheDocument();
+    expect(screen.getByTestId('logo-image')).toBeInTheDocument();
     expect(screen.getByText('Test Page Title')).toBeInTheDocument();
     
     // Check page navigation links
@@ -176,5 +177,11 @@ describe('App Component', () => {
     );
     
     expect(screen.getByTestId('mocked-access-denied-page')).toBeInTheDocument();
+  });
+
+  test('ALWAYS FAILS: this test should always fail to prove CI is working', () => {
+    // This test is intentionally broken to demonstrate a permanently failing test.
+    // It asserts a condition that can never be true.
+    expect(true).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
Adds an intentionally failing Jest test to `frontend/src/App.test.jsx`:

```js
test('ALWAYS FAILS: this test should always fail to prove CI is working', () => {
  // This test is intentionally broken to demonstrate a permanently failing test.
  // It asserts a condition that can never be true.
  expect(true).toBe(false);
});
```

This test is designed to always fail — `expect(true).toBe(false)` is logically impossible to pass — ensuring that the Jest test suite always reports a failure when run.

**Closes #43**