### PR TITLE
Add Azure Container Apps frontend deployment workflow

### DIFF
--- a/.github/workflows/.azure-container-apps.yml
+++ b/.github/workflows/.azure-container-apps.yml
@@ -1,0 +1,95 @@
+# Deploy Frontend to Azure Container Apps
+#
+# Builds the React frontend Docker image and deploys it to Azure Container Apps
+# on every merge to main. Uses OIDC federated auth — no service principal secrets.
+#
+# PREREQUISITES (must be configured in the repository + Azure):
+#  1. AZURE_CLIENT_ID    — App Registration client ID (federated identity credential)
+#  2. AZURE_TENANT_ID    — Azure tenant ID
+#  3. AZURE_SUBSCRIPTION — Azure subscription ID
+#  4. ACR_LOGIN_SERVER    — Full ACR login server (e.g. myregistry.azurecr.io)
+#  5. Container Apps environment + ACA app must exist (provisioned separately via Terraform)
+#
+# Azure-side setup for OIDC:
+#  - Create a Federated Identity Credential on the App Registration used for CI/CD:
+#    Subject: api://AzureADTokenExchange
+#    Issuer:  https://token.actions.githubusercontent.com
+#    Audience: api://AzureADTokenExchange
+name: Container Apps Frontend Deployment
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'frontend/**'
+      - '.github/workflows/.azure-container-apps.yml'
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: 'Docker image tag to deploy'
+        required: false
+        default: ''
+
+env:
+  FRONTEND_DIR: frontend
+  IMAGE_NAME: ultimate-web-stack-frontend
+  ACR_REGISTRY: ${{ secrets.ACR_LOGIN_SERVER }}
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: prod
+    permissions:
+      id-token: write
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Azure Container Registry
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION }}
+
+      - name: Login to ACR
+        run: az acr login --name ${{ env.ACR_REGISTRY }}
+
+      - name: Extract metadata (Docker labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.ACR_REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=sha,prefix=,suffix=,format=short
+            type=raw,value=latest
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ env.FRONTEND_DIR }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Deploy to Azure Container Apps
+        run: |
+          az containerapp update \
+            --name "${{ vars.ACA_APP_NAME }}" \
+            --resource-group "${{ vars.ACA_RESOURCE_GROUP }}" \
+            --image "${{ env.ACR_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}" \
+            --set-env-vars "VITE_APP_TITLE=${{ vars.APP_NAME }}" \
+            --output none
+
+      - name: Logout from Azure
+        if: always()
+        run: az logout

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,44 @@
+# Stage 1: Build the React frontend
+FROM node:22-alpine AS builder
+
+WORKDIR /app
+
+# Copy package files
+COPY package*.json ./
+COPY public/ ./public/
+COPY src/ ./src/
+COPY vite.config.js ./
+COPY .swcrc ./
+COPY jest.config.cjs ./
+COPY jest.setup.js ./
+COPY jest-preview-reporter.js ./
+COPY cypress.config.js ./
+COPY cypress/ ./cypress/
+COPY logo_src/ ./logo_src/
+
+# Install dependencies
+RUN npm ci
+
+# Create .deploy file to signal deployment mode (uses prod URLs from terraform.config.json)
+RUN touch .deploy
+
+# Build the frontend
+RUN npm run build
+
+# Stage 2: Serve with NGINX
+FROM nginx:alpine
+
+# Copy custom NGINX config
+COPY --from=builder /app/nginx.conf /etc/nginx/conf.d/default.conf
+
+# Copy built static files from builder stage
+COPY --from=builder /app/backend/dist /usr/share/nginx/html
+
+# Expose port 80
+EXPOSE 80
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+  CMD wget --no-verbose --tries=1 --spider http://localhost/ || exit 1
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,28 @@
+server {
+    listen 80;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Gzip compression
+    gzip on;
+    gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
+
+    # Cache static assets
+    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+
+    # SPA routing - serve index.html for all routes
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Health check endpoint
+    location /health {
+        access_log off;
+        return 200 "OK\n";
+        add_header Content-Type text/plain;
+    }
+}


### PR DESCRIPTION
## What
Adds a GitHub Actions workflow that builds the frontend as a Docker image and deploys it to Azure Container Apps on every merge to `main`.

### Files added
| File | Purpose |
|------|---------|
| `frontend/Dockerfile` | Multi-stage build: `node:22-alpine` builds the React app, `nginx:alpine` serves it |
| `frontend/nginx.conf` | NGINX config with SPA routing, gzip, and `/health` endpoint |
| `.github/workflows/.azure-container-apps.yml` | Reusable workflow — builds image → pushes to ACR → updates ACA revision |

### How it works
1. **Trigger:** Push to `main` that touches `frontend/**` or this workflow file
2. **Auth:** OIDC via `azure/login@v2` — no long-lived secrets, just the three Azure IDs
3. **Build:** Docker Buildx with GitHub Actions cache for fast rebuilds
4. **Deploy:** `az containerapp update` swaps the running revision to the new image tag

### Required secrets / vars (repository settings)
| Name | Kind | Description |
|------|------|-------------|
| `AZURE_CLIENT_ID` | secret | App Registration client ID (must have federated identity for GHA) |
| `AZURE_TENANT_ID` | secret | Azure tenant ID |
| `AZURE_SUBSCRIPTION` | secret | Azure subscription ID |
| `ACR_LOGIN_SERVER` | secret | ACR login server, e.g. `myregistry.azurecr.io` |
| `ACA_APP_NAME` | variable | Azure Container Apps app name |
| `ACA_RESOURCE_GROUP` | variable | Resource group containing the ACA app |
| `APP_NAME` | variable | Display name passed as `VITE_APP_TITLE` env var to the container |

> **Azure-side prerequisite:** Create a Federated Identity Credential on the App Registration used for CI/CD with subject `api://AzureADTokenExchange`, issuer `https://token.actions.githubusercontent.com`, audience `api://AzureADTokenExchange`.

Closes #45