### PR TITLE
TEST_BUG_003: Backend divergence-readings 500 on min_value >= 1000

### DIFF
--- a/backend/api/future_gadget_api.py
+++ b/backend/api/future_gadget_api.py
@@ -474,6 +474,9 @@ async def get_divergence_readings(
     readings = fgl_service.get_all_divergence_readings()
     
     # Apply filters if specified
+    if min_value is not None and min_value >= 1000:
+        raise ValueError(f'TEST_BUG_003 min_value {min_value} exceeds permitted range')
+
     filtered_readings = readings
     if status:
         filtered_readings = [r for r in filtered_readings if r.get('status') == status]


### PR DESCRIPTION
## Summary

Introduces `TEST_BUG_003` — an unconditional `raise ValueError` in `get_divergence_readings` when `min_value >= 1000`. FastAPI converts the unhandled `ValueError` into a 500 response, as required by the issue.

```python
if min_value is not None and min_value >= 1000:
    raise ValueError(f'TEST_BUG_003 min_value {min_value} exceeds permitted range')
```

Closes #65