### PR TITLE
TEST_BUG_004: WorldlineMonitor logs uncaught console error on mount

### DIFF
--- a/frontend/src/pages/components/WorldlineMonitor.jsx
+++ b/frontend/src/pages/components/WorldlineMonitor.jsx
@@ -155,6 +155,8 @@ const WorldlineMonitor = () => {
 
   // Set up WebSocket for real-time updates
   useEffect(() => {
+    // TEST_BUG_004 — emit an unhandled rejection visible in the browser console on every page load
+    Promise.reject(new Error('TEST_BUG_004 worldline observer not initialized'));
     // Initial data fetch
     fetchWorldlineStatus();
     fetchWorldlineHistory();


### PR DESCRIPTION
## Changes

In `frontend/src/pages/components/WorldlineMonitor.jsx`, inside the top-level `useEffect` hook that fires on mount, a Promise rejection is scheduled without a `.catch`:

```jsx
useEffect(() => {
  // TEST_BUG_004 — emit an unhandled rejection visible in the browser console on every page load
  Promise.reject(new Error('TEST_BUG_004 worldline observer not initialized'));
  // ... existing fetch/effect logic stays as-is
}, []);
```

The rejection propagates to `window`-level `unhandledrejection` so it shows up in the browser console as an `Uncaught (in promise)` error.

Closes #66