### PR TITLE
TEST_BUG_003: revert artificial ValueError on min_value >= 1000

### DIFF
--- a/backend/api/future_gadget_api.py
+++ b/backend/api/future_gadget_api.py
@@ -474,9 +474,6 @@ async def get_divergence_readings(
     readings = fgl_service.get_all_divergence_readings()
     
     # Apply filters if specified
-    if min_value is not None and min_value >= 1000:
-        raise ValueError(f'TEST_BUG_003 min_value {min_value} exceeds permitted range')
-
     filtered_readings = readings
     if status:
         filtered_readings = [r for r in filtered_readings if r.get('status') == status]


### PR DESCRIPTION
Closes #69

## What

Removed the artificial `ValueError` that was deliberately injected in the `get_divergence_readings` endpoint at line 477 of `future_gadget_api.py`.

The bug was introduced in commit 5dacac1 as a test fixture for the autonomous tester subsystem. With it removed, the endpoint now correctly returns HTTP 200 with an empty result set when `min_value=1000` filters out all readings (all readings are < 1.5), instead of surfacing an unhandled exception as HTTP 500.