### PR TITLE
TEST_BUG_001: status badge throws on 'phase-shift' value (Experiments page)

### DIFF
--- a/backend/mock/mock_future_gadget_lab_data_service.py
+++ b/backend/mock/mock_future_gadget_lab_data_service.py
@@ -38,3 +38,22 @@ class MockFutureGadgetLabDataService(FutureGadgetLabDataService):
         self.storage_backend = "tinydb"
         self.db = TinyDB(storage=MemoryStorage)  # type: ignore[assignment]
         self._initialize_tinydb_tables()
+        self._seed_dev_phase_shift_experiment()
+
+    def _seed_dev_phase_shift_experiment(self) -> None:
+        """Seed a 'phase-shift' status experiment for dev runtime bug validation."""
+        import datetime
+
+        phase_shift_exp = {
+            "name": "Phase Shift Validation Test",
+            "description": "Artificial experiment with phase-shift status for bug validation",
+            "status": "phase-shift",
+            "creator_id": "Tester",
+            "collaborators": [],
+            "results": "Bug validation experiment",
+            "world_line_change": 0.0,
+            "timestamp": datetime.datetime.now(datetime.timezone.utc).strftime(
+                "%Y-%m-%dT%H:%M:%S.%f"
+            )[:-3] + "Z"
+        }
+        self.experiments_table.insert(phase_shift_exp)  # type: ignore[union-attr]

--- a/frontend/src/pages/Experiments.jsx
+++ b/frontend/src/pages/Experiments.jsx
@@ -679,6 +679,9 @@ const ExperimentForm = ({ experiment, onSubmit, mode, loading }) => {
 };
 
 const getStatusBadgeColor = (status) => {
+  if (status === 'phase-shift') {
+    throw new Error('TEST_BUG_001 phase-shift badge color is undefined');
+  }
   switch (status) {
     case 'planned':
       return 'info';


### PR DESCRIPTION
## Summary

This PR introduces a deliberate runtime bug for validating the autonomous tester subsystem.

### Changes

1. **`frontend/src/pages/Experiments.jsx`** — Modified `getStatusBadgeColor` to throw `TEST_BUG_001` when `status === 'phase-shift'`:
   ```js
   if (status === 'phase-shift') {
     throw new Error('TEST_BUG_001 phase-shift badge color is undefined');
   }
   ```

2. **`backend/mock/mock_future_gadget_lab_data_service.py`** — Added `_seed_dev_phase_shift_experiment()` which inserts one experiment with `status: 'phase-shift'` into the mock DB, ensuring the React table actually invokes the broken badge renderer at runtime.

### Testing

The dev runtime (using `MockFutureGadgetLabDataService`) now returns a `phase-shift` experiment, so loading the Experiments page in dev will trigger the thrown error and surface the bug for the autonomous tester to observe.

Closes #63