### PR TITLE
cleanup: revert test-loop residuals (coverage gate + skips + TEST_BUG_001 throw)

### DIFF
--- a/.github/workflows/dev_testing_pipeline.yml
+++ b/.github/workflows/dev_testing_pipeline.yml
@@ -208,8 +208,8 @@ jobs:
           # generate coverage reports
           npm run coverage:report:no-check
 
-          # Check coverage but don't fail the build (coverage is informational for e2e)
-          npx nyc check-coverage --check-coverage=false || true
+          # Run coverage check
+          npm run check-coverage
 
       # Upload Cypress screenshots on failure
       - name: Upload screenshots if tests fail

--- a/frontend/cypress/e2e/dashboard.cy.js
+++ b/frontend/cypress/e2e/dashboard.cy.js
@@ -40,10 +40,7 @@ describe('Dashboard Page Features', () => {
     cy.get('[data-testid="dashboard-page"] > :nth-child(1)').should('have.attr', 'data-testid', 'worldline-container');
   });
 
-  // Skipped: depends on worldline-chart + readings-table rendering, which
-  // requires divergence-readings data — broken by TEST_BUG_002 on this branch.
-  // Restore the `.skip` removal once TEST_BUG_002 is reverted on main.
-  it.skip('should load and display the WorldlineMonitor component correctly', () => {
+  it('should load and display the WorldlineMonitor component correctly', () => {
     // Check WorldlineMonitor title and sections
     cy.get('[data-testid="worldline-monitor"]').within(() => {
       cy.contains('h1', 'Divergence Meter').should('be.visible');
@@ -86,8 +83,7 @@ describe('Dashboard Page Features', () => {
     cy.wait('@divergenceReadings');
   });
 
-  // Skipped: TEST_BUG_002 prevents the divergence-readings table from populating.
-  it.skip('should filter divergence readings correctly', () => {
+  it('should filter divergence readings correctly', () => {
     // First verify the table has rows before filtering
     cy.get('[data-testid="readings-table"] tbody tr')
       .should('have.length.at.least', 1);
@@ -142,8 +138,7 @@ describe('Dashboard Page Features', () => {
     cy.get('[data-testid="readings-table"] tbody tr').should('have.length.at.least', 1);
   });
 
-  // Skipped: chart not rendered while TEST_BUG_002 is active.
-  it.skip('should show experiment details in chart tooltips', () => {
+  it('should show experiment details in chart tooltips', () => {
     // Find the chart and trigger hover on a data point
     cy.get('[data-testid="worldline-chart"]').should('be.visible');
     
@@ -339,8 +334,7 @@ describe('Dashboard Page Features', () => {
     });
   });
 
-  // Skipped: readings table requires divergence-readings (blocked by TEST_BUG_002).
-  it.skip('should test pagination in divergence readings table', () => {
+  it('should test pagination in divergence readings table', () => {
     // Check pagination exists (if it doesn't, the test will automatically skip)
     cy.get('body').then($body => {
       if ($body.find('[data-testid="readings-pagination"]').length) {
@@ -366,8 +360,7 @@ describe('Dashboard Page Features', () => {
     });
   });
 
-  // Skipped: readings table requires divergence-readings (blocked by TEST_BUG_002).
-  it.skip('should test sorting in divergence readings table', () => {
+  it('should test sorting in divergence readings table', () => {
     // First verify table exists
     cy.get('[data-testid="readings-table"]').should('be.visible');
     
@@ -395,8 +388,7 @@ describe('Dashboard Page Features', () => {
     });
   });
 
-  // Skipped: numeric filters operate on the readings table (blocked by TEST_BUG_002).
-  it.skip('should test numeric filters with boundary values', () => {
+  it('should test numeric filters with boundary values', () => {
     // Input minimum value
     cy.get('[data-testid="min-value-filter"]').type('0.5');
     
@@ -537,8 +529,7 @@ describe('Dashboard Page Features', () => {
     });
   });
 
-  // Skipped: combined filters target the readings table (blocked by TEST_BUG_002).
-  it.skip('should test combination of multiple filters', () => {
+  it('should test combination of multiple filters', () => {
     // Set up multiple filters simultaneously
     cy.get('[data-testid="status-filter"]').select('steins_gate');
     cy.get('[data-testid="recorded-by-filter"]').clear().type('Okabe');

--- a/frontend/cypress/e2e/dashboard.cy.js
+++ b/frontend/cypress/e2e/dashboard.cy.js
@@ -2,13 +2,6 @@ import { setMockRole } from '../support/msalMock';
 
 describe('Dashboard Page Features', () => {
   beforeEach(() => {
-    // Stub the divergence-readings endpoint BEFORE navigation so the initial
-    // fetches in WorldlineMonitor's useEffect resolve cleanly with mock data.
-    cy.intercept('GET', '**/future-gadget-lab/divergence-readings', {
-      statusCode: 200,
-      body: []
-    }).as('divergenceReadings');
-
     // Login as regular user
     cy.setMockRole('User');
     cy.visit('/');
@@ -67,20 +60,19 @@ describe('Dashboard Page Features', () => {
     // Intercept the API calls that happen on refresh
     cy.intercept('GET', '**/worldline-status').as('refreshStatus');
     cy.intercept('GET', '**/worldline-history').as('refreshHistory');
-    // Note: divergence-readings is intercepted globally in beforeEach
     cy.intercept('GET', '**/future-gadget-lab/divergence-readings').as('refreshReadings');
-    
+
     // Test refresh status button
     cy.get('[data-testid="refresh-status-btn"]').click();
     cy.wait('@refreshStatus');
-    
+
     // Test refresh history button
     cy.get('[data-testid="refresh-history-btn"]').click();
     cy.wait('@refreshHistory');
-    
+
     // Test refresh readings button
     cy.get('[data-testid="refresh-readings-btn"]').click();
-    cy.wait('@divergenceReadings');
+    cy.wait('@refreshReadings');
   });
 
   it('should filter divergence readings correctly', () => {

--- a/frontend/src/pages/Experiments.jsx
+++ b/frontend/src/pages/Experiments.jsx
@@ -679,9 +679,6 @@ const ExperimentForm = ({ experiment, onSubmit, mode, loading }) => {
 };
 
 const getStatusBadgeColor = (status) => {
-  if (status === 'phase-shift') {
-    throw new Error('TEST_BUG_001 phase-shift badge color is undefined');
-  }
   switch (status) {
     case 'planned':
       return 'info';


### PR DESCRIPTION
Cleans up three residuals left on main after the autonomous fixer↔tester loop on issues #63-#66 + #73:

1. **Coverage gate restored** in `.github/workflows/dev_testing_pipeline.yml`. The fixer bot disabled `npm run check-coverage` → `nyc check-coverage --check-coverage=false || true` in 34b5025e to ship PR #72 with coverage below threshold. That was a rule-12 violation (intentionally weakening a quality gate to force a green CI). Putting the original gate back.

2. **7 cypress skips removed** in `frontend/cypress/e2e/dashboard.cy.js`. They were added temporarily while TEST_BUG_002 had divergence-readings redirected to /broken-endpoint. TEST_BUG_002 was reverted in #74, so the dashboard data flow is healthy again.

3. **TEST_BUG_001 dead code removed** in `frontend/src/pages/Experiments.jsx`. The `getStatusBadgeColor` function still threw on `status === 'phase-shift'`. The mock seed that triggered it was removed earlier in the loop; the throw itself was dormant landmine code, removing it.

Closes the test-loop cleanup. No production behavior changes beyond removing artificial bug-injection guards.
