### PR TITLE
Add .editorconfig for consistent editor settings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.py]
+indent_style = space
+indent_size = 4
+
+[*.{js,jsx,json,yml,yaml,tf}]
+indent_style = space
+indent_size = 2
+
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
Adds a root `.editorconfig` with minimal, common defaults across the mixed Python/JS/HCL codebase:

- `root = true`
- LF line endings, UTF-8, final newline, trim trailing whitespace for all files
- 4-space indent for `*.py`, 2-space indent for `*.{js,jsx,json,yml,yaml,tf}`
- Tabs preserved for `Makefile`-style files
- `*.md` left at editor defaults

Closes #78