### PR TITLE
Add .gitattributes for consistent line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,25 @@
+# Default: normalize text files to LF in the repo, checkout per-platform.
+* text=auto eol=lf
+
+# Windows scripts need CRLF to run reliably.
+*.ps1 text eol=crlf
+*.cmd text eol=crlf
+*.bat text eol=crlf
+
+# Shell scripts must keep LF.
+*.sh text eol=lf
+
+# Binary types used in this repo.
+*.png binary
+*.ico binary
+*.woff binary
+*.woff2 binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.pdf binary
+*.zip binary
+
+# Lock files: generated, don't diff.
+package-lock.json linguist-generated=true
+*.lock linguist-generated=true


### PR DESCRIPTION
Adds a repo-root `.gitattributes`:

- `* text=auto eol=lf` as the default
- CRLF for Windows scripts (`*.ps1`, `*.cmd`, `*.bat`); LF enforced for `*.sh`
- Explicit `binary` for binary types used here (`*.png`, `*.ico`, `*.woff`, `*.woff2`, plus jpg/jpeg/gif/pdf/zip)
- `package-lock.json` / `*.lock` marked `linguist-generated`

Closes #79