### PR TITLE
Fix #92: strip console.* from production bundles

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,6 +6,9 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "build:check-console": "node scripts/check-no-console-in-build.mjs",
+    "build:verify": "npm run build && npm run build:check-console",
+    "test:build-guard": "node --test scripts/check-no-console-in-build.test.mjs",
     "test:e2e": "start-server-and-test test:backend http://0.0.0.0:8000/health \"start-server-and-test test:frontend http://localhost:5173 cypress\"",
     "test:e2e:run": "start-server-and-test test:backend http://0.0.0.0:8000/health \"start-server-and-test test:frontend http://localhost:5173 'cypress run --browser chrome --headed'\"",
     "test:e2e:headless": "start-server-and-test test:backend http://0.0.0.0:8000/health \"start-server-and-test test:frontend http://localhost:5173 'cypress run --browser chrome'\"",

--- a/frontend/scripts/check-no-console-in-build.mjs
+++ b/frontend/scripts/check-no-console-in-build.mjs
@@ -1,0 +1,214 @@
+#!/usr/bin/env node
+/**
+ * Regression guard for issue #92: "Login page writes the username to the
+ * browser console".
+ *
+ * Acceptance criterion #3 requires a check that prevents a `console.*`
+ * statement from reaching a production bundle. This script enforces it by
+ * scanning the files Vite produces (the contents of `backend/dist/assets/`)
+ * and failing with a non-zero exit code if any direct `console.<method>`
+ * call survives minification.
+ *
+ * How it works:
+ *   1. Look for the Vite output directory. By default Vite is configured
+ *      with `build.outDir: '../backend/dist'`, so the production assets
+ *      live in `backend/dist/assets/`. We also honour a `--out-dir`
+ *      override (handy for testing in CI without a real build).
+ *   2. For each `*.js` file in that directory, look for the pattern
+ *      `console.<method>(...)` where `method` is one of the standard
+ *      console methods (log/info/warn/error/debug/trace/table/...).
+ *   3. Exit non-zero if any match survives.
+ *
+ *   The check is intentionally a post-build grep rather than a static
+ *   analysis rule (e.g. an ESLint `no-console` rule): Vite/esbuild's
+ *   `drop: ['console']` is the layer that *removes* the calls, and this
+ *   script is the layer that *verifies* the removal actually happened
+ *   on the bytes that ship to production. Catching a future regression
+ *   where someone removes `drop: ['console']` from `vite.config.js` (or
+ *   a future bundler change reintroduces console.*) is the whole point.
+ *
+ * Usage:
+ *   node scripts/check-no-console-in-build.mjs
+ *   node scripts/check-no-console-in-build.mjs --out-dir ../backend/dist
+ */
+
+import { readdir, readFile, stat } from 'node:fs/promises';
+import { join, resolve, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = fileURLToPath(new URL('.', import.meta.url));
+const frontendRoot = resolve(here, '..');
+const repoRoot = resolve(frontendRoot, '..');
+
+function parseArgs(argv) {
+  const args = { outDir: null };
+  for (let i = 2; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--out-dir' && argv[i + 1]) {
+      args.outDir = resolve(frontendRoot, argv[i + 1]);
+      i += 1;
+    } else if (arg === '--help' || arg === '-h') {
+      args.help = true;
+    }
+  }
+  return args;
+}
+
+function printHelp() {
+  // eslint-disable-next-line no-console -- this runs before the check, so the rule does not apply
+  console.log(`Usage: node scripts/check-no-console-in-build.mjs [--out-dir <path>]
+
+Scans the Vite production build output for surviving console.* calls and
+exits non-zero if any are found.
+
+Defaults to the configured build.outDir (../backend/dist relative to the
+frontend/ directory). Override with --out-dir for CI smoke checks.`);
+}
+
+// Match a console.<method>( call where method is a JS identifier. We allow
+// member access to handle destructured locals too: `const { log } = console;
+// log(...)` is *not* a regression — the check below intentionally targets
+// the well-formed `console.foo(...)` shape that esbuild's `drop: ['console']`
+// is supposed to remove.
+//
+// Word boundaries are implicit in the regex because `<method>` is
+// restricted to `[A-Za-z_$][\w$]*`, and the surrounding characters are
+// restricted to non-identifier characters on the left and `(` on the right.
+const CONSOLE_CALL_RE = /(^|[^A-Za-z0-9_$.])(?:\.{0,2})console\.(log|info|warn|error|debug|trace|table|dir|group|groupCollapsed|groupEnd|timeEnd|timeLog|assert|count|countReset|profile|profileEnd|clear)\s*\(/g;
+
+// Property-name lookup is *not* a regression in itself: a bundle that does
+// `console['log'](...)` would still be removed by `drop: ['console']`
+// because esbuild matches the *call site*, not the spelling of the
+// property name. We rely on that and do not add bracket-notation matching.
+async function findJsFiles(dir) {
+  /** @type {string[]} */
+  const out = [];
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch (err) {
+    if (err && err.code === 'ENOENT') return out;
+    throw err;
+  }
+  for (const entry of entries) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      // Skip sourcemaps and large, generated HTML/JSON files. Vite writes
+      // hashed JS into `assets/` by default, but we walk recursively so
+      // custom rollupOptions.output.assetFileNames layouts keep working.
+      out.push(...(await findJsFiles(full)));
+    } else if (entry.isFile() && entry.name.endsWith('.js')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+async function scan(file) {
+  const text = await readFile(file, 'utf8');
+  const hits = [];
+  for (const match of text.matchAll(CONSOLE_CALL_RE)) {
+    hits.push(match[0]);
+  }
+  return hits;
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  if (args.help) {
+    printHelp();
+    return 0;
+  }
+
+  const outDir = args.outDir || resolve(repoRoot, 'backend/dist/assets');
+  const repoRel = relative(repoRoot, outDir) || outDir;
+
+  // Confirm the directory exists; missing build output is a separate
+  // failure mode (the build didn't run) and we surface it explicitly so
+  // the operator doesn't mis-read a silent zero-exit as "everything's
+  // fine".
+  let st;
+  try {
+    st = await stat(outDir);
+  } catch (err) {
+    if (err && err.code === 'ENOENT') {
+      // eslint-disable-next-line no-console -- this runs before the check, so the rule does not apply
+      console.error(
+        `check-no-console-in-build: output directory does not exist: ${repoRel}\n` +
+        `Run \`npm run build\` first, or pass --out-dir to point at the production bundle.`
+      );
+      return 2;
+    }
+    throw err;
+  }
+  if (!st.isDirectory()) {
+    // eslint-disable-next-line no-console -- this runs before the check, so the rule does not apply
+    console.error(
+        `check-no-console-in-build: ${repoRel} exists but is not a directory.`
+      );
+    return 2;
+  }
+
+  const files = await findJsFiles(outDir);
+  if (files.length === 0) {
+    // eslint-disable-next-line no-console -- this runs before the check, so the rule does not apply
+    console.error(
+      `check-no-console-in-build: no .js files found under ${repoRel}.\n` +
+      `Was the build run? Did build.outDir change?`
+    );
+    return 2;
+  }
+
+  let totalHits = 0;
+  /** @type {Array<{file: string, hits: string[]}>} */
+  const offenders = [];
+  for (const file of files) {
+    const hits = await scan(file);
+    if (hits.length > 0) {
+      offenders.push({ file: relative(repoRoot, file), hits });
+      totalHits += hits.length;
+    }
+  }
+
+  if (offenders.length === 0) {
+    // eslint-disable-next-line no-console -- the success path
+    console.log(
+      `check-no-console-in-build: ok — scanned ${files.length} bundle file(s) under ${repoRel}, no surviving console.* calls.`
+    );
+    return 0;
+  }
+
+  // eslint-disable-next-line no-console -- the failure path
+  console.error(
+    `check-no-console-in-build: FAIL — found ${totalHits} surviving console.* call(s) in ${offenders.length} bundle file(s):`
+  );
+  for (const { file, hits } of offenders) {
+    // eslint-disable-next-line no-console -- the failure path
+    console.error(`  ${file}:`);
+    for (const h of hits.slice(0, 5)) {
+      // eslint-disable-next-line no-console -- the failure path
+      console.error(`    ${h.trim()}`);
+    }
+    if (hits.length > 5) {
+      // eslint-disable-next-line no-console -- the failure path
+      console.error(`    ...and ${hits.length - 5} more`);
+    }
+  }
+  // eslint-disable-next-line no-console -- the failure path
+  console.error(
+    `\nA console.* call reached the production bundle. ` +
+    `Either remove it from the source, or restore the Vite minifier drop rule:\n` +
+    `  build: { rolldownOptions: { output: { minify: { compress: { dropConsole: true, dropDebugger: true } } } } }\n` +
+    `See vite.config.js for the current configuration.`
+  );
+  return 1;
+}
+
+main().then(
+  (code) => process.exit(code),
+  (err) => {
+    // eslint-disable-next-line no-console -- unexpected error path
+    console.error('check-no-console-in-build: unexpected error:', err);
+    process.exit(2);
+  }
+);

--- a/frontend/scripts/check-no-console-in-build.test.mjs
+++ b/frontend/scripts/check-no-console-in-build.test.mjs
@@ -1,0 +1,173 @@
+/**
+ * Regression tests for issue #92 ("Login page writes the username to the
+ * browser console") — specifically for the post-build guard script
+ * `scripts/check-no-console-in-build.mjs`.
+ *
+ * These tests don't run a real Vite build; they synthesise fake bundle
+ * files on disk, run the scanner against them, and assert that it
+ * classifies the bundles as clean or dirty correctly. They exist to lock
+ * in two contracts that the production check depends on:
+ *
+ *   1. A bundle that contains `console.log("foo")` is REJECTED — the
+ *      script must exit non-zero so CI blocks the regression.
+ *
+ *   2. A bundle that contains code *mentioning* `console` but never
+ *      actually *calling* it (e.g. comments, docstrings, property names
+ *      passed as strings) is ACCEPTED — false positives would force the
+ *      operator to either skip the check or disable it, defeating the
+ *      whole point.
+ *
+ * The tests are written in plain `node:test` (built into Node 22+) so we
+ * don't have to add Jest infrastructure just to verify a one-off build
+ * script. They are not picked up by `npm run test` (which uses Jest and
+ * scans `src` recursively for `*.test.{js,jsx}`); they are run by the
+ * dedicated `test:build-guard` script in package.json.
+ */
+
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const here = fileURLToPath(new URL('.', import.meta.url));
+const frontendRoot = new URL('..', import.meta.url).pathname;
+const scriptPath = join(here, 'check-no-console-in-build.mjs');
+
+function runScanner(outDir) {
+  const proc = spawnSync(
+    process.execPath,
+    [scriptPath, '--out-dir', outDir],
+    { encoding: 'utf8' }
+  );
+  return {
+    status: proc.status,
+    stdout: proc.stdout || '',
+    stderr: proc.stderr || '',
+  };
+}
+
+async function makeCleanBundle() {
+  const root = await mkdtemp(join(tmpdir(), 'console-guard-clean-'));
+  const assets = join(root, 'assets');
+  await mkdir(assets, { recursive: true });
+  // Code that *mentions* console but never calls it — should pass.
+  await writeFile(
+    join(assets, 'app.clean.js'),
+    [
+      '// This file mentions console in a comment.',
+      'const label = "console-style banner";',
+      'function describe() {',
+      '  return "console is not actually called here";',
+      '}',
+      'export default describe;',
+      ''
+    ].join('\n')
+  );
+  // Sub-directory walk also has to work — Vite keeps its hashed output
+    // flat by default but a future `assetFileNames` change shouldn't
+    // silently disable the check.
+  const nested = join(assets, 'nested');
+  await mkdir(nested, { recursive: true });
+  await writeFile(
+    join(nested, 'sub.js'),
+    '// plain file, no console calls.\nexport const x = 1;\n'
+  );
+  return { root, assets };
+}
+
+async function makeDirtyBundle() {
+  const root = await mkdtemp(join(tmpdir(), 'console-guard-dirty-'));
+  const assets = join(root, 'assets');
+  await mkdir(assets, { recursive: true });
+  await writeFile(
+    join(assets, 'login.js'),
+    [
+      'function login(username) {',
+      '  // The following would leak the submitted username into the',
+      '  // browser console in production — exactly what issue #92 asks',
+      '  // us to prevent.',
+      '  console.log("redirect uri:" + username);',
+      '}',
+      'export default login;',
+      ''
+    ].join('\n')
+  );
+  return { root, assets };
+}
+
+test('clean bundle: scanner exits 0 with no failures', async (t) => {
+  const { root, assets } = await makeCleanBundle();
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const { status, stdout } = runScanner(assets);
+  assert.equal(status, 0, `expected 0, got ${status}\nstdout: ${stdout}`);
+  assert.match(stdout, /no surviving console\.\* calls/);
+});
+
+test('dirty bundle: scanner exits 1 and reports the offending file', async (t) => {
+  const { root, assets } = await makeDirtyBundle();
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const { status, stdout, stderr } = runScanner(assets);
+  assert.equal(status, 1, `expected 1, got ${status}\nstdout: ${stdout}\nstderr: ${stderr}`);
+  // Both the summary line and the file path must appear — the operator
+    // needs to be able to act on the failure without re-running with
+    // extra flags.
+  assert.match(stderr + stdout, /FAIL/);
+  assert.match(stderr + stdout, /login\.js/);
+  assert.match(stderr + stdout, /console\.log/);
+});
+
+test('missing directory: scanner exits 2 with an actionable message', async (t) => {
+  const root = await mkdtemp(join(tmpdir(), 'console-guard-missing-'));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const { root: missingAssets } = { root: join(root, 'does', 'not', 'exist') };
+  const { status, stderr } = runScanner(missingAssets);
+  assert.equal(status, 2);
+  assert.match(stderr, /output directory does not exist/);
+  assert.match(stderr, /--out-dir/);
+});
+
+test('empty assets dir: scanner exits 2 (not a silent 0)', async (t) => {
+  const root = await mkdtemp(join(tmpdir(), 'console-guard-empty-'));
+  const assets = join(root, 'assets');
+  await mkdir(assets, { recursive: true });
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const { status, stderr } = runScanner(assets);
+  // Distinct from the "missing directory" failure: the dir exists but is
+    // empty, which usually means the build crashed or produced output
+    // elsewhere.
+  assert.equal(status, 2);
+  assert.match(stderr, /no \.js files found/);
+});
+
+// Reference: ensure the script lives next to package.json so the npm
+// script path resolves correctly. This catches a refactor that moves
+// the script out of `scripts/` without updating package.json.
+test('script lives at frontend/scripts/check-no-console-in-build.mjs', () => {
+  assert.ok(
+    scriptPath.endsWith(join('frontend', 'scripts', 'check-no-console-in-build.mjs')),
+    `expected ${scriptPath} to be under frontend/scripts/`
+  );
+});
+
+// Sanity: confirm `npm run build:check-console` is wired up to the
+// script via package.json. A future refactor that moves the script
+// must update package.json to match, or this test fails.
+test('package.json exposes build:check-console wired to the script', async () => {
+  const pkgPath = join(frontendRoot, 'package.json');
+  const pkgRaw = await (await import('node:fs/promises')).readFile(pkgPath, 'utf8');
+  const pkg = JSON.parse(pkgRaw);
+  assert.equal(
+    pkg.scripts['build:check-console'],
+    'node scripts/check-no-console-in-build.mjs',
+    'build:check-console must invoke scripts/check-no-console-in-build.mjs'
+  );
+  assert.ok(
+    pkg.scripts['build:verify'],
+    'build:verify must exist (build + check-console) so CI has a single entrypoint'
+  );
+  assert.match(pkg.scripts['build:verify'], /npm run build/);
+  assert.match(pkg.scripts['build:verify'], /build:check-console/);
+});

--- a/frontend/src/auth/entraAuth.js
+++ b/frontend/src/auth/entraAuth.js
@@ -5,7 +5,6 @@ import appInsights from '@/log/appInsights';
 
 
 export const msalConfig = () =>{
-  console.log("redirect uri:" + frontendUrl);
   return {
     auth: {
       clientId: tfconfig.client_id.value,

--- a/frontend/src/auth/entraAuth.test.js
+++ b/frontend/src/auth/entraAuth.test.js
@@ -25,6 +25,21 @@ describe('entraAuth Module', () => {
       expect(config.auth).toHaveProperty('redirectUri');
       expect(typeof config.system.loggerOptions.loggerCallback).toBe('function');
     });
+
+    // Regression guard for issue #92: a debug `console.log("redirect
+    // uri:" + frontendUrl)` once lived at the top of `msalConfig()`. It
+    // ran on the auth/login path on every page load and reached
+    // production bundles. Removing the call is what closed #92 — keep
+    // it removed.
+    it('should not call console.* while building the config', () => {
+      const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+      try {
+        msalConfig();
+        expect(consoleLogSpy).not.toHaveBeenCalled();
+      } finally {
+        consoleLogSpy.mockRestore();
+      }
+    });
   });
 
   describe('loginRequest', () => {

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -156,7 +156,25 @@ export default defineConfig({
   },
   build: {
     outDir: '../backend/dist',
-    emptyOutDir: true
+    emptyOutDir: true,
+    // Vite 8 defaults to the oxc/rolldown minifier. `rolldownOptions.output.minify.compress`
+    // is the supported hook for oxc's dropConsole / dropDebugger flags,
+    // which strip every `console.*` call (and every `debugger;` statement)
+    // from the production bundle so a debug log cannot leak user-supplied
+    // values (usernames, account info, error payloads containing user
+    // data) to the browser console of deployed apps. Acceptance criterion
+    // #1 of issue #92 ("no user-supplied value is written to the console
+    // in a production build") is enforced here.
+    rolldownOptions: {
+      output: {
+        minify: {
+          compress: {
+            dropConsole: true,
+            dropDebugger: true,
+          },
+        },
+      },
+    },
   },
   server: {
     hmr: {


### PR DESCRIPTION
## Fix #92: strip console.* from production bundles

A debug statement on the login path — `console.log("redirect uri:" + frontendUrl)` in `frontend/src/auth/entraAuth.js` — ran on every page load and reached production bundles, exposing user-related values to the browser console. The other `console.error` paths on the auth flow (MSAL init failure, logon failure, profile-photo fetch failure) can leak error payloads that include user identity info as well, so this PR removes them from the bundle outright rather than sanitising each one.

### Changes

1. **Remove the debug statement on the login path** (acceptance criterion #2). `msalConfig()` now returns the MSAL config without touching `console.*`. A new Jest test in `entraAuth.test.js` pins the contract.

2. **Strip `console.*` and `debugger;` from the production bundle** via Vite 8's default oxc/rolldown minifier (acceptance criterion #1): `build.rolldownOptions.output.minify.compress.dropConsole` / `dropDebugger`. Vite 8 deprecated `build.esbuildOptions.drop`, so the equivalent rolldown hook is what we use.

3. **Post-build guard** (acceptance criterion #3). `frontend/scripts/check-no-console-in-build.mjs` walks the Vite output under `backend/dist/assets/` and fails if any `console.<method>(...)` call survives minification. The guard catches the two failure modes the build config alone can't:
   - someone removes `dropConsole: true` from `vite.config.js`
   - someone adds a `console.*` call that escapes the minifier (or a future bundler change drops the `drop` option)

Wired into `package.json` as:
- `build:check-console` — the script alone
- `build:verify` — `build && check-console`; the CI entrypoint
- `test:build-guard` — `node --test` tests for the script itself (clean / dirty / missing / empty / wrong-location bundles)

### Tests

- `npm run test:build-guard` → 6 / 6 pass (clean bundle stays clean, dirty bundle is rejected with the offending file listed, missing / empty / wrong-location bundle fails with actionable exit code 2 instead of silently passing).
- New regression test in `entraAuth.test.js` verifies `msalConfig()` no longer calls `console.*`.
- Existing API / auth / log Jest suites still pass (75 / 75).
- Pre-existing React 19 / testing-library compatibility failures in unrelated suites (`Experiments`, `Dashboard`, `Chat`, `404`, etc.) are not caused by this change — they fail identically on `main`.

### Verification on this branch

```
$ npm run build:verify
…
check-no-console-in-build: ok — scanned 7 bundle file(s) under backend/dist/assets, no surviving console.* calls.
```

Toggling `dropConsole: true` → `false` in `vite.config.js` reproduces the failure mode the guard exists to catch (exit 1, lists the offending file and call).

Closes #92