### PR TITLE
Add dark-mode toggle to the Settings panel (#85)

### DIFF
--- a/frontend/cypress/e2e/navigation.cy.js
+++ b/frontend/cypress/e2e/navigation.cy.js
@@ -181,10 +181,23 @@ describe('Navigation Tests with Admin Role', () => {
   it('should have working bootstrap navigation components', () => {
     // Test bootstrap navigation structure
     cy.get('[data-testid="main-navigation"]').should('have.class', 'navbar');
-    cy.get('[data-testid="main-navigation"]').should('have.class', 'bg-dark');
+    // The navbar palette now follows the dark-mode toggle (issue #85);
+    // it can be either bg-dark or bg-light depending on the active
+    // theme. Make sure one of them is set, and that the navbar's
+    // data-bs-theme attribute matches.
+    cy.get('[data-testid="main-navigation"]').then(($nav) => {
+      const isDark = $nav.hasClass('bg-dark');
+      const isLight = $nav.hasClass('bg-light');
+      expect(isDark || isLight, 'navbar should be either bg-dark or bg-light').to.equal(true);
+      if (isDark) {
+        expect($nav.attr('data-bs-theme')).to.equal('dark');
+      } else {
+        expect($nav.attr('data-bs-theme')).to.equal('light');
+      }
+    });
     cy.get('.navbar-toggler').should('exist'); // Hamburger menu
     cy.get('.navbar-collapse').should('exist'); // Collapsible content
-    
+
     // Mobile view: Test hamburger menu opens and closes
     cy.viewport('iphone-x');
     cy.get('.navbar-collapse').should('not.be.visible');
@@ -192,7 +205,7 @@ describe('Navigation Tests with Admin Role', () => {
     cy.get('.navbar-collapse').should('be.visible');
     cy.get('.navbar-toggler').click();
     cy.get('.navbar-collapse').should('not.be.visible');
-    
+
     // Reset viewport
     cy.viewport(1000, 660);
   });
@@ -380,10 +393,23 @@ describe('Navigation Tests with Bootstrap Components', () => {
   it('should have working bootstrap navigation components', () => {
     // Test bootstrap navigation structure
     cy.get('[data-testid="main-navigation"]').should('have.class', 'navbar');
-    cy.get('[data-testid="main-navigation"]').should('have.class', 'bg-dark');
+    // The navbar palette now follows the dark-mode toggle (issue #85);
+    // it can be either bg-dark or bg-light depending on the active
+    // theme. Make sure one of them is set, and that the navbar's
+    // data-bs-theme attribute matches.
+    cy.get('[data-testid="main-navigation"]').then(($nav) => {
+      const isDark = $nav.hasClass('bg-dark');
+      const isLight = $nav.hasClass('bg-light');
+      expect(isDark || isLight, 'navbar should be either bg-dark or bg-light').to.equal(true);
+      if (isDark) {
+        expect($nav.attr('data-bs-theme')).to.equal('dark');
+      } else {
+        expect($nav.attr('data-bs-theme')).to.equal('light');
+      }
+    });
     cy.get('.navbar-toggler').should('exist'); // Hamburger menu
     cy.get('.navbar-collapse').should('exist'); // Collapsible content
-    
+
     // Mobile view: Test hamburger menu opens and closes
     cy.viewport('iphone-x');
     cy.get('.navbar-collapse').should('not.be.visible');
@@ -391,7 +417,7 @@ describe('Navigation Tests with Bootstrap Components', () => {
     cy.get('.navbar-collapse').should('be.visible');
     cy.get('.navbar-toggler').click();
     cy.get('.navbar-collapse').should('not.be.visible');
-    
+
     // Reset viewport
     cy.viewport(1000, 660);
   });

--- a/frontend/cypress/e2e/settings.cy.js
+++ b/frontend/cypress/e2e/settings.cy.js
@@ -1,0 +1,126 @@
+/// <reference types="cypress" />
+
+/**
+ * End-to-end coverage for issue #85 — dark-mode toggle in Settings.
+ *
+ * Acceptance criteria exercised here:
+ *   1. A toggle in Settings switches between light and dark immediately,
+ *      without a reload.
+ *   2. The choice persists across a full page reload.
+ *   3. With no choice ever made, the OS preference is still followed.
+ *
+ * The OS-preference branch is hard to exercise from headless Cypress
+ * (the browser runs without a real user preference), so this spec drives
+ * the toggle and reload paths — the unit suite (Settings.test.jsx)
+ * covers the prefers-color-scheme branch exhaustively in jsdom.
+ */
+describe('Settings — dark mode toggle (issue #85)', () => {
+  beforeEach(() => {
+    cy.on('uncaught:exception', (err) => {
+      console.error('Uncaught exception:', err);
+      return false;
+    });
+
+    // Start every test from a known-clean theme state. The boot script
+    // reads localStorage["theme-mode"] synchronously, so wiping it here
+    // ensures we're truly on the OS-preference fallback.
+    cy.window().then((win) => {
+      win.localStorage.removeItem('theme-mode');
+    });
+    cy.visit('/settings');
+    cy.get('[data-testid="settings-page"]', { timeout: 10000 }).should('be.visible');
+  });
+
+  it('shows the Settings page with the dark-mode switch', () => {
+    cy.get('[data-testid="settings-heading"]').should('contain', 'Settings');
+    cy.get('[data-testid="settings-dark-mode-switch"]').should('exist');
+    cy.get('[data-testid="settings-current-mode-value"]').should('exist');
+  });
+
+  it('toggles the navbar palette immediately, without a reload', () => {
+    // Capture the initial theme the boot script picked for us so we
+    // know which direction to flip.
+    cy.get('[data-testid="main-navigation"]').then(($nav) => {
+      const startDark = $nav.hasClass('bg-dark');
+      const toggle = cy.get('[data-testid="settings-dark-mode-switch"]');
+
+      // Click once: palette must flip, navbar class must follow.
+      toggle.click();
+      cy.get('[data-testid="main-navigation"]').should(($navAfter) => {
+        expect($navAfter.hasClass('bg-dark')).to.equal(!startDark);
+        const expectedTheme = startDark ? 'light' : 'dark';
+        expect($navAfter.attr('data-bs-theme')).to.equal(expectedTheme);
+      });
+
+      // Click again: palette must flip back. (No reload between clicks.)
+      toggle.click();
+      cy.get('[data-testid="main-navigation"]').should(($navBack) => {
+        expect($navBack.hasClass('bg-dark')).to.equal(startDark);
+        const expectedTheme = startDark ? 'dark' : 'light';
+        expect($navBack.attr('data-bs-theme')).to.equal(expectedTheme);
+      });
+    });
+  });
+
+  it('persists the choice across a full page reload', () => {
+    // Pick a non-default theme.
+    cy.get('[data-testid="main-navigation"]').then(($nav) => {
+      const targetIsDark = !$nav.hasClass('bg-dark');
+      cy.get('[data-testid="settings-dark-mode-switch"]').click();
+      cy.get('[data-testid="main-navigation"]').should(($navAfter) => {
+        expect($navAfter.hasClass('bg-dark')).to.equal(targetIsDark);
+      });
+
+      // localStorage must now contain the explicit choice.
+      cy.window().then((win) => {
+        const stored = win.localStorage.getItem('theme-mode');
+        expect(stored).to.equal(targetIsDark ? 'dark' : 'light');
+      });
+
+      // Hard reload (real navigation, not a soft rerender).
+      cy.reload();
+
+      // Settings page should re-show with the same toggle position.
+      cy.get('[data-testid="settings-page"]').should('be.visible');
+      cy.get('[data-testid="settings-dark-mode-switch"]').should(
+        targetIsDark ? 'be.checked' : 'not.be.checked',
+      );
+      // The navbar must also reflect the same palette — that's the
+      // user-visible "the choice persists" assertion.
+      cy.get('[data-testid="main-navigation"]').should(($navReloaded) => {
+        expect($navReloaded.hasClass('bg-dark')).to.equal(targetIsDark);
+        const expectedTheme = targetIsDark ? 'dark' : 'light';
+        expect($navReloaded.attr('data-bs-theme')).to.equal(expectedTheme);
+      });
+    });
+  });
+
+  it('offers "Follow my OS preference" once an explicit choice has been made', () => {
+    // After mount with no stored preference, no follow-OS button — we're
+    // already on OS mode.
+    cy.get('[data-testid="settings-current-mode-value"]').then(($mode) => {
+      if ($mode.text().includes('Follow OS')) {
+        cy.get('[data-testid="settings-follow-os-button"]').should('not.exist');
+      }
+
+      // Pick an explicit theme.
+      cy.get('[data-testid="settings-dark-mode-switch"]').click();
+
+      // Button now appears.
+      cy.get('[data-testid="settings-follow-os-button"]').should('be.visible');
+
+      // Clicking it returns us to OS mode and hides the button.
+      cy.get('[data-testid="settings-follow-os-button"]').click();
+      cy.get('[data-testid="settings-current-mode-value"]').should('contain', 'Follow OS');
+      cy.get('[data-testid="settings-follow-os-button"]').should('not.exist');
+    });
+  });
+
+  it('exposes the Settings link in the navbar for unauthenticated visitors', () => {
+    cy.visit('/');
+    cy.get('[data-testid="main-navigation"]').should('be.visible');
+    cy.get('[data-testid="nav-settings"]').should('be.visible').click();
+    cy.url().should('include', '/settings');
+    cy.get('[data-testid="settings-page"]').should('be.visible');
+  });
+});

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,6 +6,40 @@
     <link rel="manifest" href="site.webmanifest" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>%VITE_APP_TITLE%</title>
+    <!--
+      Synchronous theme bootstrap for issue #85.
+      Runs before <body> renders so the first paint already uses the
+      correct Bootstrap 5.3 theme (`data-bs-theme` cascades from <html>
+      to every child, including navbar, cards, forms, and dropdowns).
+
+      Resolution order, in lockstep with ThemeProvider.jsx:
+        1. localStorage["theme-mode"] if it is 'light' or 'dark'.
+        2. Otherwise OS prefers-color-scheme.
+        3. Otherwise 'light' as a safe default.
+      The theme-mode='os' value is only meaningful at runtime — at boot
+      we just need the resolved theme token.
+    -->
+    <script>
+      (function () {
+        try {
+          var KEY = 'theme-mode';
+          var stored = null;
+          try { stored = window.localStorage.getItem(KEY); } catch (_) { stored = null; }
+          var theme;
+          if (stored === 'light' || stored === 'dark') {
+            theme = stored;
+          } else if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+            theme = 'dark';
+          } else {
+            theme = 'light';
+          }
+          document.documentElement.setAttribute('data-bs-theme', theme);
+        } catch (_) {
+          // If anything explodes (very old browsers), default to light.
+          document.documentElement.setAttribute('data-bs-theme', 'light');
+        }
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/jest.setup.js
+++ b/frontend/jest.setup.js
@@ -115,8 +115,40 @@ jestPreviewConfigure({
 
 global.debug = debug;
 
+// JSDOM does not implement window.matchMedia. The Settings/theme code
+// reads prefers-color-scheme to follow OS preference, so provide a
+// controllable stub. Default = light; tests that need dark override
+// via `window.__setMatchMediaDark(true)`.
+if (typeof window !== 'undefined' && typeof window.matchMedia !== 'function') {
+  const OS_QUERY = '(prefers-color-scheme: dark)';
+  let currentMatches = false;
+  const listeners = new Set();
+  window.matchMedia = (query) => {
+    const mql = {
+      matches: currentMatches,
+      media: query,
+      onchange: null,
+      addListener: (cb) => listeners.add(cb),
+      removeListener: (cb) => listeners.delete(cb),
+      addEventListener: (_evt, cb) => listeners.add(cb),
+      removeEventListener: (_evt, cb) => listeners.delete(cb),
+      dispatchEvent: () => true,
+    };
+    return mql;
+  };
+  // Test-only escape hatch. Production code never touches this.
+  window.__setMatchMediaDark = (matches) => {
+    currentMatches = !!matches;
+    const evt = { matches: currentMatches, media: OS_QUERY };
+    listeners.forEach((cb) => { try { cb(evt); } catch (_) { /* ignore */ } });
+  };
+}
+
 beforeEach(() => {
   jest.clearAllMocks();
+  if (typeof window !== 'undefined' && typeof window.__setMatchMediaDark === 'function') {
+    window.__setMatchMediaDark(false);
+  }
 });
 
 // Automatically open preview after each test

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,1 +1,18 @@
-/* fill in your css code for the application */
+/* App-level styles. */
+
+/* The hamburger button on the navbar used to carry hardcoded dark-mode
+   inline styles (white-on-translucent). Pull those into a CSS class so
+   they adapt to the active theme via [data-bs-theme]. Bootstrap 5.3
+   picks up the theme from <html data-bs-theme>, so this is enough. */
+.navbar-hamburger {
+  box-shadow: none !important;
+  background-color: transparent !important;
+}
+
+[data-bs-theme="dark"] .navbar-hamburger {
+  border-color: rgba(255, 255, 255, 0.2) !important;
+}
+
+[data-bs-theme="light"] .navbar-hamburger {
+  border-color: rgba(0, 0, 0, 0.2) !important;
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -13,50 +13,70 @@ import Dashboard from '@/pages/Dashboard';
 import Chat from '@/pages/Chat';
 // Add new imports for Experiments and DMails
 import Experiments from '@/pages/Experiments';
+// Theme + settings (issue #85 — dark-mode toggle)
+import { ThemeProvider, useTheme } from '@/theme/ThemeProvider';
+import Settings from '@/pages/Settings';
+
+/**
+ * The navbar reads the effective theme from the ThemeProvider so its
+ * palette (bg + variant) and dropdown chrome follow the user's choice
+ * without any per-component prop-drilling. The Settings nav link is
+ * public so anyone can change theme; the actual auth-protected pages
+ * still gate on ProtectedRoute.
+ */
+function ThemedNavbar() {
+  const { theme } = useTheme();
+  const isDark = theme === 'dark';
+  return (
+    <Navbar
+      bg={isDark ? 'dark' : 'light'}
+      variant={isDark ? 'dark' : 'light'}
+      data-bs-theme={theme}
+      expand="lg"
+      data-testid="main-navigation"
+    >
+      <Container className="position-relative">
+        {/* Logo and brand */}
+        <Navbar.Brand as="div" className="d-flex align-items-center">
+          <a href="https://github.com/kstrassheim/ultimate-web-stack" target="_blank" data-testid="logo-link" className="me-2">
+            <img src='logo.png' height="30" className="d-inline-block align-top" alt="logo" data-testid="logo-image" />
+          </a>
+          {document.title}
+        </Navbar.Brand>
+        {/* Place profile outside collapse, but still in the right position */}
+        <div className="d-flex ms-auto me-1 order-lg-last" data-testid="auth-navigation">
+          <EntraProfile data-testid="entra-profile" />
+        </div>
+
+        {/* Hamburger toggle button */}
+        <Navbar.Toggle
+          aria-controls="basic-navbar-nav"
+          className={`border border-secondary ${isDark ? 'navbar-dark' : 'navbar-light'} navbar-hamburger`}
+          variant={isDark ? 'dark' : 'light'}
+          data-testid="navbar-toggle"
+        />
+        {/* Collapsible navigation content */}
+        <Navbar.Collapse id="basic-navbar-nav" className="order-lg-2">
+          {/* Main navigation links */}
+          <Nav className="me-auto" data-testid="page-navigation">
+            <Nav.Link as={Link} to="/" data-testid="nav-home">Home</Nav.Link>
+            <Nav.Link as={Link} to="/dashboard" data-testid="nav-dashboard">Dashboard</Nav.Link>
+            <Nav.Link as={Link} to="/chat" data-testid="nav-chat">Chat</Nav.Link>
+            <ProtectedLink requiredRoles={["Admin"]}>
+              <Nav.Link as={Link} to="/experiments" data-testid="nav-experiments">Experiments</Nav.Link>
+            </ProtectedLink>
+            <Nav.Link as={Link} to="/settings" data-testid="nav-settings">Settings</Nav.Link>
+          </Nav>
+        </Navbar.Collapse>
+      </Container>
+    </Navbar>
+  );
+}
 
 function App() {
   return (
-    <>
-      <Navbar bg="dark" variant="dark" data-bs-theme="dark"  expand="lg" data-testid="main-navigation">
-        <Container className="position-relative">
-          {/* Logo and brand */}
-          <Navbar.Brand as="div" className="d-flex align-items-center">
-            <a href="https://github.com/kstrassheim/ultimate-web-stack" target="_blank" data-testid="logo-link" className="me-2">
-              <img src='logo.png' height="30" className="d-inline-block align-top" alt="logo" data-testid="logo-image" />
-            </a>
-            {document.title}
-          </Navbar.Brand>
-          {/* Place profile outside collapse, but still in the right position */}
-          <div className="d-flex ms-auto me-1 order-lg-last" data-testid="auth-navigation">
-            <EntraProfile data-testid="entra-profile" />
-          </div>
-                    
-          {/* Hamburger toggle button */}
-          <Navbar.Toggle 
-            aria-controls="basic-navbar-nav"
-            className="border border-secondary navbar-dark"
-            variant="dark"
-            style={{ 
-              boxShadow: 'none', 
-              backgroundColor: 'transparent',
-              borderColor: 'rgba(255, 255, 255, 0.2) !important' 
-            }}
-          />
-          {/* Collapsible navigation content */}
-          <Navbar.Collapse id="basic-navbar-nav" className="order-lg-2">
-            {/* Main navigation links */}
-            <Nav className="me-auto" data-testid="page-navigation">
-              <Nav.Link as={Link} to="/" data-testid="nav-home">Home</Nav.Link>
-              <Nav.Link as={Link} to="/dashboard" data-testid="nav-dashboard">Dashboard</Nav.Link>
-              <Nav.Link as={Link} to="/chat" data-testid="nav-chat">Chat</Nav.Link>
-              <ProtectedLink requiredRoles={["Admin"]}>
-                <Nav.Link as={Link} to="/experiments" data-testid="nav-experiments">Experiments</Nav.Link>
-              </ProtectedLink>
-            </Nav>
-          </Navbar.Collapse>
-        </Container>
-      </Navbar>
-      
+    <ThemeProvider>
+      <ThemedNavbar />
       <Container className="mt-4" data-testid="main-content">
         <Routes>
           <Route
@@ -90,11 +110,13 @@ function App() {
               </ProtectedRoute>
             }
           />
+          {/* Settings is public — anyone can change theme preference. */}
+          <Route path="/settings" element={<Settings />} />
           <Route path="/access-denied" element={<AccessDenied />} />
           <Route path="*" element={<NotFound />} />
         </Routes>
       </Container>
-    </>
+    </ThemeProvider>
   );
 }
 

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -26,12 +26,30 @@ jest.mock('@/components/ProtectedLink', () => {
   };
 });
 
+// Mock the theme system so the App's Navbar can use useTheme() without
+// bootstrapping a full provider + localStorage round-trip per test.
+jest.mock('@/theme/ThemeProvider', () => {
+  const React = require('react');
+  const useThemeMock = () => ({
+    theme: 'dark',
+    mode: 'dark',
+    setMode: jest.fn(),
+    toggleTheme: jest.fn(),
+    resetToOsPreference: jest.fn(),
+  });
+  return {
+    ThemeProvider: ({ children }) => children,
+    useTheme: useThemeMock,
+  };
+});
+
 jest.mock('@/pages/Home', () => () => <div data-testid="home-page">Home Page</div>);
 jest.mock('@/pages/Dashboard', () => () => <div data-testid="mocked-dashboard-page">Dashboard Page</div>);
 jest.mock('@/pages/Chat', () => () => <div data-testid="mocked-chat-page">Chat Page</div>);
 jest.mock('@/pages/404', () => () => <div data-testid="mocked-404-page">404 Page</div>);
 jest.mock('@/pages/AccessDenied', () => () => <div data-testid="mocked-access-denied-page">Access Denied Page</div>);
 jest.mock('@/pages/Experiments', () => () => <div data-testid="mocked-experiments-page">Experiments Page</div>);
+jest.mock('@/pages/Settings', () => () => <div data-testid="mocked-settings-page">Settings Page</div>);
 
 describe('App Component', () => {
   // Set document.title for testing
@@ -61,6 +79,7 @@ describe('App Component', () => {
     expect(screen.getByTestId('nav-home')).toBeInTheDocument();
     expect(screen.getByTestId('nav-dashboard')).toBeInTheDocument();
     expect(screen.getByTestId('nav-chat')).toBeInTheDocument();
+    expect(screen.getByTestId('nav-settings')).toBeInTheDocument();
     
     // Check protected links
     const protectedLink = screen.getByTestId('mocked-protected-link');
@@ -176,5 +195,21 @@ describe('App Component', () => {
     );
     
     expect(screen.getByTestId('mocked-access-denied-page')).toBeInTheDocument();
+  });
+
+  test('renders settings page without role protection', () => {
+    render(
+      <MemoryRouter 
+        initialEntries={['/settings']}
+        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+      >
+        <App />
+      </MemoryRouter>
+    );
+
+    // Settings is intentionally public (theme is a user-preference
+    // concern, not a security one), so no ProtectedRoute wrapper.
+    expect(screen.queryByTestId('mocked-protected-route')).not.toBeInTheDocument();
+    expect(screen.getByTestId('mocked-settings-page')).toBeInTheDocument();
   });
 });

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,1 +1,93 @@
-/* Add your custom CSS styles here */
+/* Global styles + theme-aware overrides for #85 (dark-mode toggle). */
+
+/* Smooth theme transitions on the body so the toggle feels responsive
+   rather than jumpy. Kept short enough to not interfere with tests. */
+body {
+  transition: background-color 0.18s ease, color 0.18s ease;
+}
+
+/* ----- Theme-aware overrides for custom CSS that hardcoded colors -----
+   Bootstrap 5.3 cascades the right palette for stock components via
+   `<html data-bs-theme>`, but the project's own .css files (Chat.css,
+   Home.css, ...) bake in light-mode values. Override them per theme. */
+
+/* Home feature cards: in dark mode the card titles (#007bff) and body
+   text (#6c757d) need brighter equivalents. */
+[data-bs-theme="dark"] .feature-card .card-title {
+  color: #66b3ff;
+}
+
+[data-bs-theme="dark"] .feature-card .card-text {
+  color: #adb5bd;
+}
+
+/* Chat surface: chat container and message bubbles use explicit
+   near-white backgrounds that disappear on a dark canvas. */
+[data-bs-theme="dark"] .chat-container {
+  background-color: #212529;
+  border-color: #343a40;
+}
+
+[data-bs-theme="dark"] .chat-container h2 {
+  background-color: #1c1f23;
+  border-bottom-color: #343a40;
+}
+
+[data-bs-theme="dark"] .status-indicator {
+  background-color: #1c1f23;
+  border-bottom-color: #343a40;
+}
+
+[data-bs-theme="dark"] .chat-input {
+  background-color: #1c1f23;
+}
+
+[data-bs-theme="dark"] .chat-input input {
+  background-color: #2b3035;
+  color: #f8f9fa;
+  border-color: #495057;
+}
+
+[data-bs-theme="dark"] .message.sent {
+  background-color: #056162;
+  color: #f8f9fa;
+}
+
+[data-bs-theme="dark"] .message.received {
+  background-color: #2b3035;
+  color: #f8f9fa;
+  border-color: #3a3f44;
+}
+
+[data-bs-theme="dark"] .chat-input button {
+  background-color: #2d6a4f;
+}
+
+[data-bs-theme="dark"] .chat-input button:hover {
+  background-color: #40916c;
+}
+
+/* Dashboard cards: original CSS hardcodes a transparent surface. In
+   dark mode it blends with the page background; give the card a
+   subtle outline. */
+[data-bs-theme="dark"] .card {
+  background-color: #212529;
+  border-color: #343a40;
+}
+
+/* EntraProfile dropdown menu items: the menu uses variant="dark" only
+   in dark mode — make the light variant readable too. */
+[data-bs-theme="light"] .dropdown-menu {
+  background-color: #ffffff;
+  border-color: rgba(0, 0, 0, 0.15);
+}
+
+[data-bs-theme="light"] .dropdown-item {
+  color: #212529;
+}
+
+[data-bs-theme="light"] .dropdown-item:hover,
+[data-bs-theme="light"] .dropdown-item:focus {
+  background-color: #f8f9fa;
+  color: #1a1a1a;
+}

--- a/frontend/src/pages/Settings.css
+++ b/frontend/src/pages/Settings.css
@@ -1,0 +1,5 @@
+/* Settings page — currently relies on Bootstrap 5.3 tokens
+   (`data-bs-theme` cascades from <html>) so no per-mode overrides are
+   needed here. Kept as a separate file to match the per-page style
+   convention used by Home.css, Chat.css, etc., so any future
+   theme-specific tweaks have an obvious home. */

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -1,0 +1,101 @@
+import { Card, Form } from 'react-bootstrap';
+import { useTheme } from '@/theme/ThemeProvider';
+import appInsights from '@/log/appInsights';
+import './Settings.css';
+
+/**
+ * Settings page — exposes a dark-mode toggle wired into the global
+ * ThemeProvider. The switch reflects the *effective* theme (so it
+ * also works correctly when the user has no explicit choice and the
+ * page is rendering in dark because their OS prefers dark).
+ *
+ * Acceptance criteria for issue #85:
+ *   1. Toggling the switch swaps light↔dark immediately, no reload.
+ *   2. The choice is written to localStorage so a full reload keeps it.
+ *   3. With no stored choice, the OS preference is followed — and a
+ *      "Follow my OS preference" button is offered so users who picked
+ *      manually can return to auto.
+ */
+const Settings = () => {
+  const { theme, mode, setMode, resetToOsPreference } = useTheme();
+  const isDark = theme === 'dark';
+
+  const handleThemeToggle = (event) => {
+    const next = event.target.checked ? 'dark' : 'light';
+    appInsights.trackEvent({
+      name: 'Settings - Theme toggled',
+      properties: { from: mode, to: next },
+    });
+    setMode(next);
+  };
+
+  const handleFollowOs = () => {
+    appInsights.trackEvent({
+      name: 'Settings - Reset to OS preference',
+      properties: { previousMode: mode },
+    });
+    resetToOsPreference();
+  };
+
+  return (
+    <div data-testid="settings-page">
+      <h1 data-testid="settings-heading">Settings</h1>
+
+      <Card className="mb-4" data-bs-theme={theme} data-testid="settings-appearance-card">
+        <Card.Header data-testid="settings-appearance-header">Appearance</Card.Header>
+        <Card.Body>
+          <div
+            className="d-flex justify-content-between align-items-center"
+            data-testid="settings-theme-row"
+          >
+            <div>
+              <Form.Label
+                htmlFor="settings-dark-mode-switch"
+                className="fw-semibold mb-1"
+                data-testid="settings-theme-label"
+              >
+                Dark mode
+              </Form.Label>
+              <div className="text-muted small" data-testid="settings-theme-help">
+                {isDark
+                  ? 'The interface is currently using the dark palette.'
+                  : 'The interface is currently using the light palette.'}
+              </div>
+            </div>
+            <Form.Check
+              type="switch"
+              id="settings-dark-mode-switch"
+              name="dark-mode"
+              aria-label="Toggle dark mode"
+              checked={isDark}
+              onChange={handleThemeToggle}
+              data-testid="settings-dark-mode-switch"
+            />
+          </div>
+
+          <hr className="my-3" />
+
+          <div data-testid="settings-current-mode">
+            <span className="text-muted small me-2">Current mode:</span>
+            <span data-testid="settings-current-mode-value" className="badge bg-secondary">
+              {mode === 'os' ? 'Follow OS' : mode === 'dark' ? 'Dark' : 'Light'}
+            </span>
+          </div>
+
+          {mode !== 'os' && (
+            <button
+              type="button"
+              className="btn btn-link p-0 mt-2"
+              onClick={handleFollowOs}
+              data-testid="settings-follow-os-button"
+            >
+              Follow my OS preference
+            </button>
+          )}
+        </Card.Body>
+      </Card>
+    </div>
+  );
+};
+
+export default Settings;

--- a/frontend/src/pages/Settings.test.jsx
+++ b/frontend/src/pages/Settings.test.jsx
@@ -1,0 +1,187 @@
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import Settings from './Settings';
+import { ThemeProvider } from '@/theme/ThemeProvider';
+import { THEME_STORAGE_KEY } from '@/theme/ThemeProvider';
+import appInsights from '@/log/appInsights';
+
+// Mock appInsights so we don't depend on the Application Insights
+// transport in tests.
+jest.mock('@/log/appInsights', () => ({
+  trackEvent: jest.fn(),
+  trackException: jest.fn(),
+}));
+
+// Helper: drive the JSDOM matchMedia stub (installed in jest.setup.js).
+const setOsDark = (matches) => {
+  if (typeof window !== 'undefined' && typeof window.__setMatchMediaDark === 'function') {
+    window.__setMatchMediaDark(matches);
+  }
+};
+
+const renderSettings = (initialStoredMode) => {
+  if (initialStoredMode === null || initialStoredMode === undefined) {
+    window.localStorage.removeItem(THEME_STORAGE_KEY);
+  } else {
+    window.localStorage.setItem(THEME_STORAGE_KEY, initialStoredMode);
+  }
+  return render(
+    <ThemeProvider>
+      <Settings />
+    </ThemeProvider>,
+  );
+};
+
+describe('Settings — theme toggle (issue #85)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setOsDark(false); // OS defaults to light in every test unless overridden
+    window.localStorage.removeItem(THEME_STORAGE_KEY);
+    document.documentElement.removeAttribute('data-bs-theme');
+  });
+
+  test('renders the page and the dark-mode switch', () => {
+    renderSettings();
+    expect(screen.getByTestId('settings-page')).toBeInTheDocument();
+    expect(screen.getByTestId('settings-heading')).toHaveTextContent('Settings');
+    expect(screen.getByTestId('settings-dark-mode-switch')).toBeInTheDocument();
+  });
+
+  test('reflects OS light preference when no choice has been made', () => {
+    setOsDark(false);
+    renderSettings(); // no stored mode
+    const toggle = screen.getByTestId('settings-dark-mode-switch');
+    expect(toggle).not.toBeChecked();
+    expect(screen.getByTestId('settings-current-mode-value')).toHaveTextContent('Follow OS');
+    expect(document.documentElement.getAttribute('data-bs-theme')).toBe('light');
+  });
+
+  test('reflects OS dark preference when no choice has been made', () => {
+    setOsDark(true);
+    renderSettings(); // no stored mode
+    const toggle = screen.getByTestId('settings-dark-mode-switch');
+    expect(toggle).toBeChecked();
+    expect(screen.getByTestId('settings-current-mode-value')).toHaveTextContent('Follow OS');
+    expect(document.documentElement.getAttribute('data-bs-theme')).toBe('dark');
+  });
+
+  test('toggling the switch swaps theme immediately and persists the choice', () => {
+    setOsDark(false);
+    renderSettings();
+
+    const toggle = screen.getByTestId('settings-dark-mode-switch');
+    expect(toggle).not.toBeChecked();
+
+    // Flip to dark.
+    act(() => {
+      toggle.click();
+    });
+    expect(toggle).toBeChecked();
+    expect(document.documentElement.getAttribute('data-bs-theme')).toBe('dark');
+    expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe('dark');
+
+    // Flip back to light.
+    act(() => {
+      toggle.click();
+    });
+    expect(toggle).not.toBeChecked();
+    expect(document.documentElement.getAttribute('data-bs-theme')).toBe('light');
+    expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe('light');
+  });
+
+  test('stored "dark" choice wins over an OS light preference', () => {
+    setOsDark(false);
+    renderSettings('dark');
+    const toggle = screen.getByTestId('settings-dark-mode-switch');
+    expect(toggle).toBeChecked();
+    expect(screen.getByTestId('settings-current-mode-value')).toHaveTextContent('Dark');
+    expect(document.documentElement.getAttribute('data-bs-theme')).toBe('dark');
+  });
+
+  test('stored "light" choice wins over an OS dark preference', () => {
+    setOsDark(true);
+    renderSettings('light');
+    const toggle = screen.getByTestId('settings-dark-mode-switch');
+    expect(toggle).not.toBeChecked();
+    expect(screen.getByTestId('settings-current-mode-value')).toHaveTextContent('Light');
+    expect(document.documentElement.getAttribute('data-bs-theme')).toBe('light');
+  });
+
+  test('"Follow my OS preference" button is hidden while already following OS', () => {
+    setOsDark(false);
+    renderSettings(); // mode defaults to os
+    expect(screen.queryByTestId('settings-follow-os-button')).not.toBeInTheDocument();
+  });
+
+  test('"Follow my OS preference" returns to OS mode and is hidden afterwards', () => {
+    setOsDark(true);
+    renderSettings('light'); // start with an explicit light override
+    expect(screen.getByTestId('settings-current-mode-value')).toHaveTextContent('Light');
+    const followBtn = screen.getByTestId('settings-follow-os-button');
+    expect(followBtn).toBeInTheDocument();
+
+    act(() => {
+      fireEvent.click(followBtn);
+    });
+
+    expect(screen.getByTestId('settings-current-mode-value')).toHaveTextContent('Follow OS');
+    // Now resolves to OS dark.
+    expect(document.documentElement.getAttribute('data-bs-theme')).toBe('dark');
+    expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe('os');
+    // Button disappears once we're back to OS mode.
+    expect(screen.queryByTestId('settings-follow-os-button')).not.toBeInTheDocument();
+  });
+
+  test('toggling emits a telemetry event', () => {
+    renderSettings('light');
+    const toggle = screen.getByTestId('settings-dark-mode-switch');
+    act(() => {
+      toggle.click();
+    });
+    expect(appInsights.trackEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'Settings - Theme toggled',
+        properties: expect.objectContaining({ to: 'dark' }),
+      }),
+    );
+  });
+
+  test('survives a simulated full reload: stored mode is read on mount', () => {
+    // Simulate the user choosing dark and the page being reloaded.
+    window.localStorage.setItem(THEME_STORAGE_KEY, 'dark');
+    render(
+      <ThemeProvider>
+        <Settings />
+      </ThemeProvider>,
+    );
+    expect(screen.getByTestId('settings-dark-mode-switch')).toBeChecked();
+    expect(document.documentElement.getAttribute('data-bs-theme')).toBe('dark');
+  });
+
+  test('OS preference changes propagate when mode is "os"', () => {
+    setOsDark(false);
+    renderSettings(); // no stored mode → follows OS
+    expect(document.documentElement.getAttribute('data-bs-theme')).toBe('light');
+
+    act(() => {
+      setOsDark(true);
+    });
+
+    expect(document.documentElement.getAttribute('data-bs-theme')).toBe('dark');
+    expect(screen.getByTestId('settings-dark-mode-switch')).toBeChecked();
+  });
+
+  test('OS preference changes are ignored when an explicit choice is set', () => {
+    setOsDark(false);
+    renderSettings('dark'); // explicit dark, OS starts light
+    expect(document.documentElement.getAttribute('data-bs-theme')).toBe('dark');
+
+    act(() => {
+      setOsDark(true); // OS flips to dark — must not affect explicit choice
+    });
+
+    expect(document.documentElement.getAttribute('data-bs-theme')).toBe('dark');
+    expect(screen.getByTestId('settings-dark-mode-switch')).toBeChecked();
+  });
+});

--- a/frontend/src/theme/ThemeProvider.jsx
+++ b/frontend/src/theme/ThemeProvider.jsx
@@ -1,0 +1,119 @@
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+
+/**
+ * Theme system for #85 — dark-mode toggle in Settings.
+ *
+ * Three logical states are tracked:
+ *   - `mode`  : what the user asked for. 'light', 'dark', or 'os'.
+ *   - `theme` : the effective Bootstrap theme currently applied. Always
+ *               'light' or 'dark'. When `mode === 'os'` this resolves
+ *               from `prefers-color-scheme` and follows OS changes.
+ *
+ * Persistence: `mode` is stored in localStorage under the key
+ * `theme-mode`. Missing/invalid values fall back to 'os'.
+ *
+ * The active theme is mirrored to `<html data-bs-theme="...">` so the
+ * Bootstrap 5.3 theme tokens (body bg, navbar palette, modal chrome,
+ * form controls, etc.) cascade everywhere without per-component work.
+ * The inline boot script in `index.html` performs the same assignment
+ * synchronously before React mounts to avoid a flash of the wrong theme
+ * on first paint.
+ */
+
+export const THEME_STORAGE_KEY = 'theme-mode';
+const OS_QUERY = '(prefers-color-scheme: dark)';
+
+function readStoredMode() {
+  if (typeof window === 'undefined') return 'os';
+  try {
+    const value = window.localStorage.getItem(THEME_STORAGE_KEY);
+    if (value === 'light' || value === 'dark' || value === 'os') return value;
+  } catch (_) {
+    // localStorage can throw (private mode, disabled). Treat as no choice.
+  }
+  return 'os';
+}
+
+function writeStoredMode(mode) {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(THEME_STORAGE_KEY, mode);
+  } catch (_) {
+    // Ignore write errors — toggle still works for the current session.
+  }
+}
+
+function detectOsTheme() {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return 'light';
+  }
+  return window.matchMedia(OS_QUERY).matches ? 'dark' : 'light';
+}
+
+function resolveTheme(mode, osTheme) {
+  return mode === 'os' ? osTheme : mode;
+}
+
+const ThemeContext = createContext(null);
+
+export function ThemeProvider({ children }) {
+  const [mode, setModeState] = useState(readStoredMode);
+  const [osTheme, setOsTheme] = useState(detectOsTheme);
+  const theme = resolveTheme(mode, osTheme);
+
+  // Mirror the effective theme to <html data-bs-theme> for Bootstrap 5.3.
+  useEffect(() => {
+    if (typeof document === 'undefined') return;
+    document.documentElement.setAttribute('data-bs-theme', theme);
+  }, [theme]);
+
+  // When the user is in 'os' mode, follow live OS preference changes.
+  // When they have made an explicit choice we ignore OS flips so their
+  // preference is not silently overridden by an OS theme swap.
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return;
+    if (mode !== 'os') return undefined;
+    const mq = window.matchMedia(OS_QUERY);
+    const handler = (event) => setOsTheme(event.matches ? 'dark' : 'light');
+    if (typeof mq.addEventListener === 'function') {
+      mq.addEventListener('change', handler);
+      return () => mq.removeEventListener('change', handler);
+    }
+    // Older Safari (pre-14) only supports the deprecated addListener API.
+    if (typeof mq.addListener === 'function') {
+      mq.addListener(handler);
+      return () => mq.removeListener(handler);
+    }
+    return undefined;
+  }, [mode]);
+
+  const setMode = useCallback((next) => {
+    if (next !== 'light' && next !== 'dark' && next !== 'os') return;
+    setModeState(next);
+    writeStoredMode(next);
+    if (next !== 'os') setOsTheme(next);
+  }, []);
+
+  const toggleTheme = useCallback(() => {
+    setMode(theme === 'dark' ? 'light' : 'dark');
+  }, [theme, setMode]);
+
+  const resetToOsPreference = useCallback(() => {
+    setMode('os');
+  }, [setMode]);
+
+  const value = useMemo(
+    () => ({ theme, mode, setMode, toggleTheme, resetToOsPreference }),
+    [theme, mode, setMode, toggleTheme, resetToOsPreference],
+  );
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+}
+
+export function useTheme() {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) {
+    throw new Error('useTheme must be used inside <ThemeProvider>');
+  }
+  return ctx;
+}


### PR DESCRIPTION
Closes #85

Adds a public **Settings** page with a Bootstrap switch that flips the
whole UI between light and dark **immediately**, persists the choice
in `localStorage`, and falls back to OS `prefers-color-scheme` when
no choice has been made.

### How it works

- **`frontend/src/theme/ThemeProvider.jsx`** owns the `(mode, theme)`
  state. `mode` is the user's choice (`'light' | 'dark' | 'os'`);
  `theme` is the resolved Bootstrap palette (`'light' | 'dark'`). It
  mirrors the resolved theme onto `<html data-bs-theme>`, and listens
  to `prefers-color-scheme` changes only while the user is in `'os'`
  mode — so an explicit choice is never silently overridden by an OS
  theme flip.
- **`frontend/index.html`** runs the same resolution synchronously in
  `<head>` so the first paint already uses the right Bootstrap
  palette (no flash of wrong theme).
- **`frontend/src/App.jsx`** wraps the tree in `ThemeProvider`. The
  navbar (`ThemedNavbar`) reads the current theme to pick
  `bg`/`variant`/`data-bs-theme` for the navbar and its hamburger
  button. The new `/settings` route is public — theme preference is
  a user-preference concern, not a security one.
- **`frontend/src/App.css`** + **`frontend/src/index.css`** add the
  per-theme overrides that `Chat.css`, `Home.css`, and `Dashboard.css`
  need (those files hardcode light values that disappear on a dark
  canvas).

### Acceptance criteria coverage

| # | Criterion | Where |
|---|-----------|-------|
| 1 | Toggle swaps light↔dark immediately, no reload | `Settings.jsx` `onChange` → `setMode()` → context re-render → `<html data-bs-theme>` flips + navbar `bg` flips in the same tick |
| 2 | Choice persists across a full page reload | `localStorage["theme-mode"]` written on every explicit change; `index.html` boot script reads it before React mounts |
| 3 | No choice made → OS preference is followed | `matchMedia('(prefers-color-scheme: dark)')` is the fallback at boot and at runtime when `mode === 'os'`; a "Follow my OS preference" link lets users who picked manually return to auto |

### Tests

- **`frontend/src/pages/Settings.test.jsx`** — 12 unit tests (all
  pass), covering every branch:
  - renders the page + switch
  - reflects OS light/dark when no choice
  - toggling flips `data-bs-theme` + writes `localStorage`
  - stored `light`/`dark` wins over OS
  - "Follow my OS preference" appears only after an explicit choice
    and resets to OS mode
  - telemetry events emitted
  - simulated reload re-reads stored mode
  - OS preference changes propagate only when in OS mode
- **`frontend/cypress/e2e/settings.cy.js`** — new e2e suite:
  - toggle flips navbar palette immediately (no reload)
  - explicit choice survives `cy.reload()` (navbar still has the
    expected `bg-` class + `data-bs-theme` attribute)
  - "Follow my OS preference" reset round-trip
  - Settings nav link works for unauthenticated visitors
- **`frontend/cypress/e2e/navigation.cy.js`** — updated two
  assertions that hard-coded `bg-dark` to accept either `bg-dark` or
  `bg-light` (the navbar is now theme-aware) and to assert the
  `data-bs-theme` attribute matches.
- **`frontend/src/App.test.jsx`** — mocks `ThemeProvider` + `Settings`
  so existing route tests stay isolated, plus a new test that the
  `/settings` route is public (no `ProtectedRoute` wrapper).
- **`frontend/jest.setup.js`** — adds a `matchMedia` polyfill that
  jsdom doesn't ship, plus a `window.__setMatchMediaDark` escape hatch
  for the OS-branch tests.

### Verification

- `npm run test` (Jest): **21 suites, 193 tests, all green**
- `npm run test:coverage`: coverage thresholds met (Settings.jsx
  100% statements/branches/functions/lines; ThemeProvider.jsx ~86%
  lines — global thresholds 80/70/80/80 satisfied)
- `npm run build:verify`: Vite production build succeeds and the
  post-build `console.*` guard reports clean
- `node --test scripts/check-no-console-in-build.test.mjs`: 6/6 pass

### Notes

- No existing tests were modified to lower coverage thresholds or
  skip gates — coverage is checked globally and stays above the
  current bar.
- No `console.*` calls were introduced in the new source files.
- The `theme-mode = 'os'` value is only meaningful at runtime; the
  boot script just needs the resolved `'light'`/`'dark'` token.