### PR TITLE
Add CSV export to the divergence readings table (Closes #88)

### DIFF
--- a/frontend/cypress/e2e/csvExport.cy.js
+++ b/frontend/cypress/e2e/csvExport.cy.js
@@ -1,0 +1,279 @@
+// E2E tests for the divergence-readings CSV export button on the
+// WorldlineMonitor dashboard. Exercises the production download path
+// (handleExportReadingsCsv -> divergenceReadingsToCsv -> rowsToCsv ->
+// escapeCsvField, plus downloadCsv -> Blob -> URL.createObjectURL ->
+// <a download> click) end-to-end so the new code is covered by the
+// coverage threshold that e2e-tests enforces.
+
+import { setMockRole } from '../support/msalMock';
+
+describe('Divergence readings CSV export', () => {
+  // Capture state shared between the page-side setup and the test
+  // body. Server-side `cy.window()` writes here; the test reads it
+  // back after the click.
+  let capture;
+
+  // Install stubs on URL.createObjectURL / URL.revokeObjectURL and
+  // document.createElement so the production download path can run
+  // end-to-end inside jsdom (which doesn't actually persist blob
+  // downloads). The blobs handed to URL.createObjectURL are kept
+  // around for assertions on the CSV payload.
+  //
+  // MUST be called AFTER the dashboard page has loaded - cy.visit
+  // creates a new window context, so any earlier installation gets
+  // thrown away. `signInAndOpenDashboard` calls this once the table
+  // has rendered.
+  const installDownloadSpy = () => {
+    capture = {
+      blobs: [],
+      anchorDownload: null,
+      anchorClickCount: 0,
+      anchorElements: []
+    };
+    cy.window().then((win) => {
+      // Wrap the Blob constructor so the parts Array is preserved
+      // on the instance. jsdom's Blob doesn't expose its constructor
+      // arguments, so this is the only way to assert on the literal
+      // CSV payload.
+      const OriginalBlob = win.Blob;
+      function WrappedBlob(parts, options) {
+        const instance = new OriginalBlob(parts, options);
+        try {
+          instance.__rawParts = Array.isArray(parts) ? parts.slice() : [parts];
+          instance.__options = options;
+        } catch (e) {
+          // Some Blob implementations are non-extensible; skip the
+          // capture but still let the Blob be created.
+        }
+        return instance;
+      }
+      WrappedBlob.prototype = OriginalBlob.prototype;
+      Object.setPrototypeOf(WrappedBlob, OriginalBlob);
+      // Preserve static properties so `Blob.[Symbol.species]` etc.
+      // still work for code that uses them.
+      Object.defineProperty(WrappedBlob, 'name', { value: 'Blob' });
+      win.Blob = WrappedBlob;
+
+      win.URL.createObjectURL = (blob) => {
+        capture.blobs.push(blob);
+        return 'blob:cypress-csv-export';
+      };
+      win.URL.revokeObjectURL = () => {
+        // No-op; the spy just needs to exist so downloadCsv doesn't
+        // throw on the deferred revocation.
+      };
+
+      const originalCreateElement = win.document.createElement.bind(win.document);
+      win.document.createElement = (tag) => {
+        const el = originalCreateElement(tag);
+        if (tag && tag.toLowerCase() === 'a') {
+          capture.anchorElements.push(el);
+          const originalClick = el.click.bind(el);
+          el.click = () => {
+            capture.anchorClickCount += 1;
+            capture.anchorDownload = el.download;
+            return originalClick();
+          };
+        }
+        return el;
+      };
+    });
+  };
+
+  // Read the CSV payload out of a captured blob. The capture above
+  // stores the original parts array in `__rawParts` so the test
+  // can assert on the literal CSV text without depending on Blob
+  // internals across jsdom versions.
+  const blobToCsv = (blob) => {
+    if (blob && Array.isArray(blob.__rawParts)) {
+      return blob.__rawParts.join('');
+    }
+    if (blob && typeof blob.text === 'function') {
+      return blob.text();
+    }
+    return '';
+  };
+
+  // Drive the sign-in + dashboard navigation that the other
+  // dashboard.cy.js tests use. MOCK=true backend seeds 5 readings
+  // (mix of steins_gate / alpha / beta by Rintaro Okabe / Suzuha
+  // Amane) so the export has something to serialize.
+  const signInAndOpenDashboard = () => {
+    cy.setMockRole('User');
+    cy.visit('/');
+    cy.get('[data-testid="sign-in-button"]').click();
+    cy.get('[data-testid="nav-dashboard"]').click();
+    cy.get('[data-testid="dashboard-page"]', { timeout: 10000 }).should('be.visible');
+    cy.get('[data-testid="worldline-container"]', { timeout: 15000 }).should('be.visible');
+    cy.get('[data-testid="loading-overlay"]', { timeout: 10000 }).should('not.exist');
+    cy.get('[data-testid="readings-table"]', { timeout: 15000 }).should('be.visible');
+    // Install the URL/document spies AFTER the dashboard page has
+    // loaded so the production downloadCsv runs against our stubs.
+    installDownloadSpy();
+  };
+
+  it('renders the Export CSV button on the divergence readings card', () => {
+    signInAndOpenDashboard();
+    cy.get('[data-testid="divergence-readings-card"]').within(() => {
+      cy.get('[data-testid="export-readings-csv-btn"]')
+        .should('be.visible')
+        .and('not.be.disabled')
+        .and('contain.text', /export.*csv/i);
+    });
+  });
+
+  it('clicking Export CSV downloads a CSV with header row and respects table order', () => {
+    signInAndOpenDashboard();
+
+    // Capture the visible row order on screen — the export must
+    // match this order (acceptance criterion #2).
+    const visibleReadingIds = [];
+    cy.get('[data-testid="readings-table"] tbody tr').each(($row) => {
+      const testId = $row.attr('data-testid') || '';
+      const m = testId.match(/^reading-row-(.+)$/);
+      if (m) visibleReadingIds.push(m[1]);
+    });
+
+    cy.get('[data-testid="export-readings-csv-btn"]').click();
+
+    // Cypress serialises asynchronous commands through a queue, so
+    // read the captured state through a `wrap(null)` to make sure the
+    // click chain has fully resolved before we assert.
+    cy.wrap(null).then(() => {
+      expect(capture.blobs).to.have.length(1, 'URL.createObjectURL was called exactly once');
+      const blob = capture.blobs[0];
+      expect(blob.__options).to.deep.include({
+        type: 'text/csv;charset=utf-8;'
+      });
+
+      const raw = blobToCsv(blob);
+      // UTF-8 BOM at the start so Excel decodes non-ASCII correctly.
+      expect(raw.charCodeAt(0)).to.equal(0xfeff);
+      const csv = raw.slice(1);
+      const lines = csv.split('\r\n').filter((line) => line.length > 0);
+
+      // Header row in the documented column order.
+      expect(lines[0]).to.equal('Reading,Status,Recorded By,Notes');
+      // One data row per visible table row.
+      const dataRows = lines.slice(1);
+      expect(dataRows.length).to.equal(visibleReadingIds.length);
+
+      // Anchor click was triggered and the filename is set.
+      expect(capture.anchorClickCount).to.equal(1);
+      expect(capture.anchorDownload).to.match(/^divergence-readings-\d{4}-\d{2}-\d{2}\.csv$/);
+    });
+  });
+
+  it('export respects the active status filter (only matching rows are exported)', () => {
+    signInAndOpenDashboard();
+
+    cy.get('[data-testid="status-filter"]').select('steins_gate');
+    cy.get('[data-testid="readings-table"] tbody tr').should('have.length', 1);
+
+    cy.get('[data-testid="export-readings-csv-btn"]').click();
+
+    cy.wrap(null).then(() => {
+      expect(capture.blobs).to.have.length(1);
+      const csv = blobToCsv(capture.blobs[0]).slice(1); // drop BOM
+      const lines = csv.split('\r\n').filter((line) => line.length > 0);
+      // Header + exactly one filtered row.
+      expect(lines).to.have.length(2);
+      expect(lines[1]).to.include('steins_gate');
+    });
+  });
+
+  it('export button is disabled when no readings are visible', () => {
+    // Force the readings endpoint to return an empty list so the
+    // disabled-state branch of the export button is exercised.
+    // Install this interception BEFORE the dashboard loads so the
+    // initial fetch returns [].
+    cy.intercept('GET', '**/future-gadget-lab/divergence-readings', {
+      statusCode: 200,
+      body: []
+    }).as('emptyReadings');
+
+    // Manual navigation that doesn't need the readings table to be
+    // populated — the button should be disabled either way.
+    cy.setMockRole('User');
+    cy.visit('/');
+    cy.get('[data-testid="sign-in-button"]').click();
+    cy.get('[data-testid="nav-dashboard"]').click();
+    cy.get('[data-testid="dashboard-page"]', { timeout: 10000 }).should('be.visible');
+    cy.get('[data-testid="worldline-container"]', { timeout: 15000 }).should('be.visible');
+    cy.get('[data-testid="loading-overlay"]', { timeout: 10000 }).should('not.exist');
+    // Don't wait for readings-table — it never renders when the
+    // list is empty (the component shows "no-readings" instead).
+    installDownloadSpy();
+
+    cy.get('[data-testid="export-readings-csv-btn"]').should('be.disabled');
+    // The handler must not have been invoked — no blob, no anchor click.
+    expect(capture.anchorClickCount).to.equal(0);
+  });
+
+  it('export correctly escapes commas, quotes, and newlines in field values', () => {
+    // Inject readings with characters that need RFC 4180 escaping.
+    // The default mock data set doesn't include any commas / quotes
+    // / newlines, so without this interception the escape branch
+    // of escapeCsvField is never hit by the e2e suite.
+    cy.intercept('GET', '**/future-gadget-lab/divergence-readings', {
+      statusCode: 200,
+      body: [
+        {
+          id: 'DR-001',
+          reading: 1.048596,
+          status: 'steins_gate',
+          recorded_by: 'Doe, John',
+          notes: 'Said "hello"\nthen left'
+        }
+      ]
+    }).as('escapeReadings');
+
+    cy.setMockRole('User');
+    cy.visit('/');
+    cy.get('[data-testid="sign-in-button"]').click();
+    cy.get('[data-testid="nav-dashboard"]').click();
+    cy.get('[data-testid="dashboard-page"]', { timeout: 10000 }).should('be.visible');
+    cy.get('[data-testid="worldline-container"]', { timeout: 15000 }).should('be.visible');
+    cy.get('[data-testid="loading-overlay"]', { timeout: 10000 }).should('not.exist');
+    cy.get('[data-testid="readings-table"]', { timeout: 15000 }).should('be.visible');
+    installDownloadSpy();
+
+    cy.get('[data-testid="export-readings-csv-btn"]').click();
+
+    cy.wrap(null).then(() => {
+      expect(capture.blobs).to.have.length(1);
+      const csv = blobToCsv(capture.blobs[0]).slice(1); // drop BOM
+      const lines = csv.split('\r\n');
+      // Header + one row that contains a newline embedded in a
+      // quoted field. The split('\r\n') leaves the embedded LF
+      // inside the row, so the unique "data" line count is 2
+      // (header + the row that wraps the multi-line quoted field).
+      // Filter out any trailing empty element from the joined CRLF.
+      const dataLines = lines.filter((line) => line.length > 0);
+      expect(dataLines.length).to.be.at.least(2);
+      // The row line must contain the escaped comma + escaped quotes.
+      expect(dataLines[1]).to.include('"Doe, John"');
+      expect(dataLines[1]).to.include('"Said ""hello""');
+    });
+  });
+
+  it('export surfaces a user-visible error when the download pipeline throws', () => {
+    signInAndOpenDashboard();
+
+    // Drive the failure branch of handleExportReadingsCsv by making
+    // URL.createObjectURL throw. The production handler catches and
+    // surfaces a notyf error; this exercises both the catch block
+    // and the telemetry path.
+    cy.window().then((win) => {
+      win.URL.createObjectURL = () => {
+        throw new Error('boom');
+      };
+    });
+
+    cy.get('[data-testid="export-readings-csv-btn"]').click();
+
+    cy.get('.notyf__toast--error', { timeout: 5000 })
+      .should('be.visible')
+      .and('contain.text', 'Failed to export readings: boom');
+  });
+});

--- a/frontend/src/pages/components/WorldlineMonitor.jsx
+++ b/frontend/src/pages/components/WorldlineMonitor.jsx
@@ -13,6 +13,11 @@ import {
 import appInsights from '@/log/appInsights';
 import Loading from '@/components/Loading';
 import notyfService from '@/log/notyfService';
+import { downloadCsv } from '@/utils/csvExport';
+import {
+  divergenceReadingsToCsv,
+  divergenceReadingsCsvFilename
+} from '@/utils/divergenceReadingsCsv';
 
 // Helper function to get status color
 const getStatusColor = (status) => {
@@ -151,6 +156,22 @@ const WorldlineMonitor = () => {
       maxValue: ''
     });
     setFilteredReadings(readings);
+  };
+
+  // Export the currently visible readings (post-filter, in their
+  // current on-screen order) as a CSV file. The button is disabled
+  // when there is nothing to export, so the click handler can
+  // assume filteredReadings is non-empty.
+  const handleExportReadingsCsv = () => {
+    try {
+      appInsights.trackEvent({ name: 'Worldline - Exporting divergence readings CSV' });
+      const csv = divergenceReadingsToCsv(filteredReadings);
+      downloadCsv(divergenceReadingsCsvFilename(), csv);
+      notyfService.success('Divergence readings exported');
+    } catch (err) {
+      notyfService.error(`Failed to export readings: ${err.message}`);
+      appInsights.trackException({ error: err });
+    }
   };
 
   // Set up WebSocket for real-time updates
@@ -673,15 +694,26 @@ const WorldlineMonitor = () => {
       <Card className="mb-4" data-testid="divergence-readings-card">
         <Card.Header className="d-flex justify-content-between align-items-center">
           <span>Divergence Meter Readings</span>
-          <Button
-            variant="outline-primary"
-            size="sm"
-            onClick={fetchDivergenceReadings}
-            disabled={loading.readings}
-            data-testid="refresh-readings-btn"
-          >
-            Refresh
-          </Button>
+          <div className="d-flex gap-2">
+            <Button
+              variant="outline-secondary"
+              size="sm"
+              onClick={handleExportReadingsCsv}
+              disabled={loading.readings || filteredReadings.length === 0}
+              data-testid="export-readings-csv-btn"
+            >
+              Export CSV
+            </Button>
+            <Button
+              variant="outline-primary"
+              size="sm"
+              onClick={fetchDivergenceReadings}
+              disabled={loading.readings}
+              data-testid="refresh-readings-btn"
+            >
+              Refresh
+            </Button>
+          </div>
         </Card.Header>
         <Card.Body>
           {/* Filters */}

--- a/frontend/src/pages/components/WorldlineMonitor.test.jsx
+++ b/frontend/src/pages/components/WorldlineMonitor.test.jsx
@@ -13,12 +13,26 @@ import {
 } from '@/api/futureGadgetApi';
 import appInsights from '@/log/appInsights';
 import notyfService from '@/log/notyfService';
+import { downloadCsv } from '@/utils/csvExport';
+import {
+  divergenceReadingsToCsv,
+  divergenceReadingsCsvFilename
+} from '@/utils/divergenceReadingsCsv';
 
 // Mock the dependencies
 jest.mock('@azure/msal-react');
 jest.mock('@/api/futureGadgetApi');
 jest.mock('@/log/appInsights');
 jest.mock('@/log/notyfService');
+jest.mock('@/utils/csvExport', () => ({
+  __esModule: true,
+  downloadCsv: jest.fn()
+}));
+jest.mock('@/utils/divergenceReadingsCsv', () => ({
+  __esModule: true,
+  divergenceReadingsToCsv: jest.fn(() => 'Reading,Status,Recorded By,Notes\r\n1,alpha,X,Y\r\n'),
+  divergenceReadingsCsvFilename: jest.fn(() => 'divergence-readings-test.csv')
+}));
 
 // Improved mock for react-apexcharts to test annotations (horizontal lines)
 jest.mock('react-apexcharts', () => {
@@ -439,4 +453,137 @@ describe('WorldlineMonitor', () => {
     expect(unsubscribeStatusMock).toHaveBeenCalled();
     expect(worldlineSocket.disconnect).toHaveBeenCalled();
   });
+
+  // -------- CSV export of divergence readings --------
+
+  // Helper: render the component and wait for the readings table to
+  // be populated. Returns the rendered instance so individual tests
+  // can poke at it.
+  const renderAndLoadReadings = async () => {
+    const utils = render(<WorldlineMonitor />);
+    await waitFor(() => {
+      expect(screen.getByTestId('readings-table')).toBeInTheDocument();
+    });
+    return utils;
+  };
+
+  test('renders an Export CSV button on the readings card', async () => {
+    await renderAndLoadReadings();
+    const button = screen.getByTestId('export-readings-csv-btn');
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveTextContent(/export.*csv/i);
+  });
+
+  test('clicking Export CSV serialises the currently visible rows and triggers a download', async () => {
+    await renderAndLoadReadings();
+
+    // Sanity: the export was built from the post-filter row list, in
+    // the same order the user sees them. The mock readings happen to
+    // come back in the mock fetch order; assert that the helper is
+    // called with that exact list (not a re-sorted / re-filtered
+    // copy).
+    fireEvent.click(screen.getByTestId('export-readings-csv-btn'));
+
+    expect(divergenceReadingsToCsv).toHaveBeenCalledTimes(1);
+    expect(divergenceReadingsToCsv).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'DR-001' }),
+        expect.objectContaining({ id: 'DR-002' }),
+        expect.objectContaining({ id: 'DR-003' })
+      ])
+    );
+
+    expect(divergenceReadingsCsvFilename).toHaveBeenCalledTimes(1);
+    expect(downloadCsv).toHaveBeenCalledTimes(1);
+    expect(downloadCsv).toHaveBeenCalledWith(
+      'divergence-readings-test.csv',
+      'Reading,Status,Recorded By,Notes\r\n1,alpha,X,Y\r\n'
+    );
+
+    // Success notification for the user.
+    expect(notyfService.success).toHaveBeenCalledWith('Divergence readings exported');
+    // Telemetry for the export action.
+    expect(appInsights.trackEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'Worldline - Exporting divergence readings CSV'
+      })
+    );
+  });
+
+  test('export honours an active status filter (only filtered rows are exported)', async () => {
+    await renderAndLoadReadings();
+
+    // Apply a filter that keeps only the steins_gate row.
+    fireEvent.change(screen.getByTestId('status-filter'), {
+      target: { name: 'status', value: 'steins_gate' }
+    });
+
+    // The filter is applied via useEffect on the [filters, readings]
+    // dependency — wait for the row count to drop.
+    await waitFor(() => {
+      const rows = screen.getAllByTestId(/^reading-row-/);
+      expect(rows).toHaveLength(1);
+    });
+
+    divergenceReadingsToCsv.mockClear();
+    downloadCsv.mockClear();
+    fireEvent.click(screen.getByTestId('export-readings-csv-btn'));
+
+    // Only the single matching reading should have been handed off
+    // to the serializer.
+    expect(divergenceReadingsToCsv).toHaveBeenCalledTimes(1);
+    const rowsArg = divergenceReadingsToCsv.mock.calls[0][0];
+    expect(rowsArg).toHaveLength(1);
+    expect(rowsArg[0]).toMatchObject({ id: 'DR-001', status: 'steins_gate' });
+    expect(downloadCsv).toHaveBeenCalledTimes(1);
+  });
+
+  test('export respects the order of currently visible rows (a sort / re-order input)', async () => {
+    // Customise the mock to return rows in a non-default order and
+    // make sure the export passes them through verbatim.
+    getDivergenceReadings.mockResolvedValueOnce([
+      { id: 'DR-003', reading: 1.382733, status: 'beta', recorded_by: 'Suzuha Amane', notes: 'Beta worldline variant' },
+      { id: 'DR-001', reading: 1.048596, status: 'steins_gate', recorded_by: 'Rintaro Okabe', notes: 'Steins;Gate worldline' },
+      { id: 'DR-002', reading: 0.571024, status: 'alpha', recorded_by: 'Rintaro Okabe', notes: 'Alpha worldline' }
+    ]);
+
+    await renderAndLoadReadings();
+
+    fireEvent.click(screen.getByTestId('export-readings-csv-btn'));
+
+    const rowsArg = divergenceReadingsToCsv.mock.calls[0][0];
+    // Order in the export matches the order the rows came back in.
+    expect(rowsArg.map((r) => r.id)).toEqual(['DR-003', 'DR-001', 'DR-002']);
+  });
+
+  test('export button is disabled when there are no visible readings', async () => {
+    getDivergenceReadings.mockResolvedValueOnce([]);
+    render(<WorldlineMonitor />);
+    await waitFor(() => {
+      expect(screen.queryByTestId('readings-table')).not.toBeInTheDocument();
+    });
+    // No readings → no readings table, but the export button is still
+    // rendered in the card header. The handler shouldn't fire.
+    const button = screen.getByTestId('export-readings-csv-btn');
+    expect(button).toBeInTheDocument();
+    expect(button).toBeDisabled();
+  });
+
+  test('export surfaces a user-visible error if the serializer throws', async () => {
+    await renderAndLoadReadings();
+
+    divergenceReadingsToCsv.mockImplementationOnce(() => {
+      throw new Error('boom');
+    });
+
+    fireEvent.click(screen.getByTestId('export-readings-csv-btn'));
+
+    // No download should have been attempted.
+    expect(downloadCsv).not.toHaveBeenCalled();
+    expect(notyfService.error).toHaveBeenCalledWith(
+      'Failed to export readings: boom'
+    );
+    expect(appInsights.trackException).toHaveBeenCalled();
+  });
 });
+

--- a/frontend/src/utils/csvExport.js
+++ b/frontend/src/utils/csvExport.js
@@ -1,0 +1,105 @@
+/**
+ * CSV export utilities.
+ *
+ * Pure, side-effect-free serializers for turning structured rows into an
+ * RFC 4180-style CSV string, plus a tiny browser download helper. Kept
+ * separate from the React components so the escape rules are easy to unit
+ * test in isolation and so the same helpers can be reused for other
+ * tables in the future.
+ */
+
+/**
+ * Escape a single field for CSV output per RFC 4180.
+ *
+ * - null / undefined are rendered as the empty string.
+ * - Non-string values are coerced via String() so the caller can pass
+ *   numbers, booleans, etc. without thinking about it.
+ * - Fields containing a comma, double quote, CR or LF are wrapped in
+ *   double quotes.
+ * - Internal double quotes are escaped by doubling them (`"` -> `""`).
+ *
+ * @param {*} value Field value of any type.
+ * @returns {string} Escaped CSV field, without the surrounding field
+ *   separator (the caller adds the comma or line break).
+ */
+export const escapeCsvField = (value) => {
+  if (value === null || value === undefined) {
+    return '';
+  }
+
+  // String() handles numbers, booleans, dates etc. consistently.
+  let str;
+  if (value instanceof Date) {
+    str = value.toISOString();
+  } else {
+    str = String(value);
+  }
+
+  const needsQuoting = /[",\r\n]/.test(str);
+  if (!needsQuoting) {
+    return str;
+  }
+
+  return `"${str.replace(/"/g, '""')}"`;
+};
+
+/**
+ * Build a CSV string from a list of column headers and an array of row
+ * objects.
+ *
+ * Each row is serialised in the order of `headers`. Missing or
+ * undefined fields render as the empty string. Uses CRLF line endings
+ * (RFC 4180 default) so tools like Microsoft Excel on Windows open
+ * the file without complaints.
+ *
+ * @param {string[]} headers Column header names, in the order they
+ *   should appear in the output.
+ * @param {Array<object>} rows Row objects keyed by header name.
+ * @returns {string} The full CSV document including the header row.
+ */
+export const rowsToCsv = (headers, rows) => {
+  const headerLine = headers.map(escapeCsvField).join(',');
+  const bodyLines = rows.map((row) =>
+    headers.map((h) => escapeCsvField(row?.[h])).join(',')
+  );
+  return [headerLine, ...bodyLines].join('\r\n') + '\r\n';
+};
+
+/**
+ * Trigger a browser download of the given CSV text.
+ *
+ * Creates a Blob URL, attaches it to a temporary `<a download>` element,
+ * clicks it, and revokes the URL. The anchor is not appended to the
+ * DOM — modern browsers honour the `download` attribute on a detached
+ * element. The download runs asynchronously; the function returns as
+ * soon as the click has been dispatched.
+ *
+ * Safe to call only in the browser. In non-browser environments
+ * (e.g. jsdom in some configurations) `URL.createObjectURL` is
+ * available but no actual download happens; the tests in this repo
+ * stub `URL.createObjectURL` and `document.createElement` to assert
+ * on the inputs.
+ *
+ * @param {string} filename Suggested filename for the download.
+ * @param {string} csvText CSV document text (UTF-8).
+ */
+export const downloadCsv = (filename, csvText) => {
+  if (typeof document === 'undefined' || typeof URL === 'undefined') {
+    // Not a browser environment — nothing to do.
+    return;
+  }
+
+  // BOM so Excel detects UTF-8 correctly when the CSV contains
+  // non-ASCII characters (e.g. names like "Suzuha Amane").
+  const blob = new Blob(['\uFEFF', csvText], { type: 'text/csv;charset=utf-8;' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  // Detached element is fine for the `download` attribute to work.
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  // Give the browser a tick to start the download before revoking.
+  setTimeout(() => URL.revokeObjectURL(url), 0);
+};

--- a/frontend/src/utils/csvExport.test.js
+++ b/frontend/src/utils/csvExport.test.js
@@ -1,0 +1,198 @@
+import {
+  escapeCsvField,
+  rowsToCsv,
+  downloadCsv
+} from './csvExport';
+
+describe('escapeCsvField', () => {
+  it('returns plain strings unchanged when no special chars are present', () => {
+    expect(escapeCsvField('hello')).toBe('hello');
+    expect(escapeCsvField('Okabe Rintaro')).toBe('Okabe Rintaro');
+  });
+
+  it('returns an empty string for null or undefined', () => {
+    expect(escapeCsvField(null)).toBe('');
+    expect(escapeCsvField(undefined)).toBe('');
+  });
+
+  it('coerces non-string scalars to their string form', () => {
+    expect(escapeCsvField(42)).toBe('42');
+    expect(escapeCsvField(0)).toBe('0');
+    expect(escapeCsvField(false)).toBe('false');
+    expect(escapeCsvField(true)).toBe('true');
+  });
+
+  it('renders Date values as ISO 8601 strings', () => {
+    const iso = '2025-04-07T12:34:56.789Z';
+    expect(escapeCsvField(new Date(iso))).toBe(iso);
+  });
+
+  it('wraps fields containing commas in double quotes', () => {
+    expect(escapeCsvField('a, b')).toBe('"a, b"');
+  });
+
+  it('wraps fields containing double quotes and doubles them', () => {
+    expect(escapeCsvField('she said "hi"')).toBe('"she said ""hi"""');
+  });
+
+  it('wraps fields containing CR or LF', () => {
+    expect(escapeCsvField('line1\nline2')).toBe('"line1\nline2"');
+    expect(escapeCsvField('line1\r\nline2')).toBe('"line1\r\nline2"');
+  });
+
+  it('handles each special character independently', () => {
+    expect(escapeCsvField('comma,here')).toBe('"comma,here"');
+    expect(escapeCsvField('quote"here')).toBe('"quote""here"');
+    expect(escapeCsvField('cr\rhere')).toBe('"cr\rhere"');
+    expect(escapeCsvField('lf\nhere')).toBe('"lf\nhere"');
+  });
+
+  it('handles empty strings without quoting', () => {
+    expect(escapeCsvField('')).toBe('');
+  });
+});
+
+describe('rowsToCsv', () => {
+  it('emits a header row followed by one row per object', () => {
+    const csv = rowsToCsv(
+      ['name', 'value'],
+      [
+        { name: 'alpha', value: 1 },
+        { name: 'beta', value: 2 }
+      ]
+    );
+    expect(csv).toBe('name,value\r\nalpha,1\r\nbeta,2\r\n');
+  });
+
+  it('emits only the header line for an empty row list', () => {
+    expect(rowsToCsv(['a', 'b'], [])).toBe('a,b\r\n');
+  });
+
+  it('renders missing fields as the empty string', () => {
+    const csv = rowsToCsv(
+      ['a', 'b', 'c'],
+      [{ a: 1 }, { a: 2, b: 'x' }, { c: 'z' }]
+    );
+    expect(csv).toBe('a,b,c\r\n1,,\r\n2,x,\r\n,,z\r\n');
+  });
+
+  it('escapes commas, quotes, and newlines inside cell values', () => {
+    const csv = rowsToCsv(
+      ['note'],
+      [
+        { note: 'has, comma' },
+        { note: 'has "quote"' },
+        { note: 'has\nnewline' }
+      ]
+    );
+    expect(csv).toBe(
+      'note\r\n"has, comma"\r\n"has ""quote"""\r\n"has\nnewline"\r\n'
+    );
+  });
+
+  it('preserves the header order in each row', () => {
+    const csv = rowsToCsv(
+      ['z', 'a', 'm'],
+      [{ a: 1, z: 2, m: 3 }]
+    );
+    expect(csv).toBe('z,a,m\r\n2,1,3\r\n');
+  });
+});
+
+describe('downloadCsv', () => {
+  let originalCreateObjectURL;
+  let originalRevokeObjectURL;
+  let originalCreateElement;
+  let originalAppendChild;
+  let originalRemoveChild;
+
+  beforeEach(() => {
+    originalCreateObjectURL = URL.createObjectURL;
+    originalRevokeObjectURL = URL.revokeObjectURL;
+    originalCreateElement = document.createElement.bind(document);
+    originalAppendChild = document.body.appendChild.bind(document.body);
+    originalRemoveChild = document.body.removeChild.bind(document.body);
+  });
+
+  afterEach(() => {
+    URL.createObjectURL = originalCreateObjectURL;
+    URL.revokeObjectURL = originalRevokeObjectURL;
+    document.createElement = originalCreateElement;
+    document.body.appendChild = originalAppendChild;
+    document.body.removeChild = originalRemoveChild;
+    jest.useRealTimers();
+  });
+
+  it('creates a Blob URL, clicks an anchor, and revokes the URL', () => {
+    // Spy on the Blob constructor so we can assert on the exact
+    // payload without depending on jsdom's Blob features (which
+    // differ from real browsers — e.g. no .arrayBuffer() in this
+    // version of jsdom).
+    const OriginalBlob = global.Blob;
+    const blobSpy = jest.fn(function (parts, options) {
+      const instance = new OriginalBlob(parts, options);
+      instance.__parts = parts;
+      instance.__options = options;
+      return instance;
+    });
+    global.Blob = blobSpy;
+
+    try {
+      jest.useFakeTimers();
+      const createObjectURL = jest.fn(() => 'blob:fake-url');
+      const revokeObjectURL = jest.fn();
+      URL.createObjectURL = createObjectURL;
+      URL.revokeObjectURL = revokeObjectURL;
+
+      const click = jest.fn();
+      const anchor = { href: '', download: '', click };
+      const createElement = jest.fn((tag) => {
+        if (tag === 'a') return anchor;
+        return originalCreateElement(tag);
+      });
+      const appendChild = jest.fn();
+      const removeChild = jest.fn();
+      document.createElement = createElement;
+      document.body.appendChild = appendChild;
+      document.body.removeChild = removeChild;
+
+      downloadCsv('readings.csv', 'name,value\r\nalpha,1\r\n');
+
+      expect(createObjectURL).toHaveBeenCalledTimes(1);
+      const blob = createObjectURL.mock.calls[0][0];
+      expect(blob).toBeInstanceOf(OriginalBlob);
+      // The Blob was constructed with the UTF-8 BOM prefix + the CSV
+      // body, and the right MIME type — the latter is what determines
+      // how the browser handles the download.
+      expect(blobSpy).toHaveBeenCalledWith(
+        ['\uFEFF', 'name,value\r\nalpha,1\r\n'],
+        { type: 'text/csv;charset=utf-8;' }
+      );
+
+      expect(appendChild).toHaveBeenCalledWith(anchor);
+      expect(anchor.href).toBe('blob:fake-url');
+      expect(anchor.download).toBe('readings.csv');
+      expect(click).toHaveBeenCalledTimes(1);
+      expect(removeChild).toHaveBeenCalledWith(anchor);
+
+      jest.runAllTimers();
+      expect(revokeObjectURL).toHaveBeenCalledWith('blob:fake-url');
+    } finally {
+      global.Blob = OriginalBlob;
+    }
+  });
+
+  it('is a no-op when document or URL are not defined', () => {
+    const originalDocument = global.document;
+    const originalURL = global.URL;
+    delete global.document;
+    delete global.URL;
+
+    try {
+      expect(() => downloadCsv('x.csv', 'a,b\r\n')).not.toThrow();
+    } finally {
+      global.document = originalDocument;
+      global.URL = originalURL;
+    }
+  });
+});

--- a/frontend/src/utils/divergenceReadingsCsv.js
+++ b/frontend/src/utils/divergenceReadingsCsv.js
@@ -1,0 +1,87 @@
+/**
+ * Divergence-readings-specific CSV builder.
+ *
+ * Owns the column shape of the "Divergence Meter Readings" table
+ * export so the React component doesn't have to know the header
+ * order, what to call each column, or how to coerce the underlying
+ * reading number to a string.
+ *
+ * The exported rows respect whatever filter / sort state the calling
+ * component already applied — this function does NOT re-filter. The
+ * caller is expected to pass the rows in the order the user sees
+ * them in the table.
+ */
+
+import { rowsToCsv } from './csvExport';
+
+// Column shape of the readings table, in the order the user sees
+// them on screen. Header text matches the `<th>` strings in
+// WorldlineMonitor.jsx so the CSV is recognisable.
+export const DIVERGENCE_READINGS_CSV_COLUMNS = [
+  'Reading',
+  'Status',
+  'Recorded By',
+  'Notes'
+];
+
+/**
+ * Pick the raw numeric reading value from a divergence readings
+ * record, accepting either `reading` or `value` for backward
+ * compatibility with both old and new backend shapes.
+ */
+const pickReadingValue = (reading) => {
+  if (reading === null || reading === undefined) return null;
+  if (reading.reading !== null && reading.reading !== undefined) {
+    return reading.reading;
+  }
+  if (reading.value !== null && reading.value !== undefined) {
+    return reading.value;
+  }
+  return null;
+};
+
+/**
+ * Build a CSV string for the divergence meter readings table.
+ *
+ * - `rows` is the list of readings to export, already filtered /
+ *   sorted by the caller.
+ * - The output is RFC 4180-compliant and uses CRLF line endings
+ *   so it opens cleanly in Excel.
+ * - Header names match the on-screen table columns.
+ * - Fields containing commas, quotes, or newlines are escaped by
+ *   the underlying rowsToCsv helper.
+ *
+ * @param {Array<object>} rows Filtered, sorted divergence readings.
+ * @returns {string} CSV document text.
+ */
+export const divergenceReadingsToCsv = (rows) => {
+  const safeRows = Array.isArray(rows) ? rows : [];
+  const projected = safeRows.map((reading) => {
+    const value = pickReadingValue(reading);
+    return {
+      'Reading': value === null || value === undefined ? '' : value,
+      'Status': reading?.status ?? '',
+      'Recorded By': reading?.recorded_by ?? '',
+      'Notes': reading?.notes ?? ''
+    };
+  });
+  return rowsToCsv(DIVERGENCE_READINGS_CSV_COLUMNS, projected);
+};
+
+/**
+ * Suggest a filename for a divergence-readings CSV download.
+ *
+ * The date in the filename is the local calendar date so users can
+ * tell at a glance which export they're looking at. Format is the
+ * ISO 8601 short form `YYYY-MM-DD` for filesystem compatibility.
+ *
+ * @param {Date} [now] Override for the current date — exposed for
+ *   deterministic testing.
+ * @returns {string} Filename like `divergence-readings-2025-04-07.csv`.
+ */
+export const divergenceReadingsCsvFilename = (now = new Date()) => {
+  const yyyy = now.getFullYear();
+  const mm = String(now.getMonth() + 1).padStart(2, '0');
+  const dd = String(now.getDate()).padStart(2, '0');
+  return `divergence-readings-${yyyy}-${mm}-${dd}.csv`;
+};

--- a/frontend/src/utils/divergenceReadingsCsv.test.js
+++ b/frontend/src/utils/divergenceReadingsCsv.test.js
@@ -1,0 +1,128 @@
+import {
+  DIVERGENCE_READINGS_CSV_COLUMNS,
+  divergenceReadingsToCsv,
+  divergenceReadingsCsvFilename
+} from './divergenceReadingsCsv';
+
+describe('divergenceReadingsToCsv', () => {
+  it('emits the header row in on-screen column order', () => {
+    const csv = divergenceReadingsToCsv([]);
+    expect(csv).toBe(
+      DIVERGENCE_READINGS_CSV_COLUMNS.join(',') + '\r\n'
+    );
+    expect(DIVERGENCE_READINGS_CSV_COLUMNS).toEqual([
+      'Reading',
+      'Status',
+      'Recorded By',
+      'Notes'
+    ]);
+  });
+
+  it('maps each reading to a CSV row in the same order as the table', () => {
+    const readings = [
+      {
+        id: 'DR-001',
+        reading: 1.048596,
+        status: 'steins_gate',
+        recorded_by: 'Rintaro Okabe',
+        notes: 'Steins;Gate worldline'
+      },
+      {
+        id: 'DR-002',
+        reading: 0.571024,
+        status: 'alpha',
+        recorded_by: 'Rintaro Okabe',
+        notes: 'Alpha worldline'
+      }
+    ];
+
+    const csv = divergenceReadingsToCsv(readings);
+    expect(csv).toBe(
+      'Reading,Status,Recorded By,Notes\r\n' +
+      '1.048596,steins_gate,Rintaro Okabe,Steins;Gate worldline\r\n' +
+      '0.571024,alpha,Rintaro Okabe,Alpha worldline\r\n'
+    );
+  });
+
+  it('preserves the caller-supplied order (filter / sort state)', () => {
+    const rows = [
+      { id: 'a', reading: 3, status: 'alpha', recorded_by: 'X', notes: 'A' },
+      { id: 'b', reading: 1, status: 'beta', recorded_by: 'Y', notes: 'B' },
+      { id: 'c', reading: 2, status: 'gamma', recorded_by: 'Z', notes: 'C' }
+    ];
+    const csv = divergenceReadingsToCsv(rows);
+    // Reading column in the export matches the input order
+    // 3, 1, 2 — no hidden resort happens in here.
+    expect(csv).toBe(
+      'Reading,Status,Recorded By,Notes\r\n' +
+      '3,alpha,X,A\r\n' +
+      '1,beta,Y,B\r\n' +
+      '2,gamma,Z,C\r\n'
+    );
+  });
+
+  it('accepts readings that use "value" instead of "reading"', () => {
+    const csv = divergenceReadingsToCsv([
+      { value: 0.571024, status: 'alpha', recorded_by: 'Rintaro Okabe', notes: 'Alpha' }
+    ]);
+    expect(csv).toBe(
+      'Reading,Status,Recorded By,Notes\r\n' +
+      '0.571024,alpha,Rintaro Okabe,Alpha\r\n'
+    );
+  });
+
+  it('renders missing fields as the empty string', () => {
+    const csv = divergenceReadingsToCsv([
+      { id: 'r1', reading: 1.0 }
+    ]);
+    expect(csv).toBe(
+      'Reading,Status,Recorded By,Notes\r\n1,,,\r\n'
+    );
+  });
+
+  it('handles a non-array input as an empty export', () => {
+    expect(divergenceReadingsToCsv(undefined)).toBe(
+      'Reading,Status,Recorded By,Notes\r\n'
+    );
+    expect(divergenceReadingsToCsv(null)).toBe(
+      'Reading,Status,Recorded By,Notes\r\n'
+    );
+  });
+
+  it('escapes commas, double quotes, and newlines in any column', () => {
+    const csv = divergenceReadingsToCsv([
+      {
+        reading: 1.0,
+        status: 'alpha',
+        recorded_by: 'Doe, John',
+        notes: 'Said "hello"\nthen left'
+      }
+    ]);
+    expect(csv).toBe(
+      'Reading,Status,Recorded By,Notes\r\n' +
+      '1,alpha,"Doe, John","Said ""hello""\nthen left"\r\n'
+    );
+  });
+});
+
+describe('divergenceReadingsCsvFilename', () => {
+  it('builds an ISO-dated filename from a Date', () => {
+    expect(divergenceReadingsCsvFilename(new Date(2025, 3, 7))).toBe(
+      'divergence-readings-2025-04-07.csv'
+    );
+  });
+
+  it('zero-pads single-digit months and days', () => {
+    expect(divergenceReadingsCsvFilename(new Date(2025, 0, 1))).toBe(
+      'divergence-readings-2025-01-01.csv'
+    );
+    expect(divergenceReadingsCsvFilename(new Date(2025, 8, 9))).toBe(
+      'divergence-readings-2025-09-09.csv'
+    );
+  });
+
+  it('defaults to the current date when no argument is given', () => {
+    const name = divergenceReadingsCsvFilename();
+    expect(name).toMatch(/^divergence-readings-\d{4}-\d{2}-\d{2}\.csv$/);
+  });
+});


### PR DESCRIPTION
Closes #88

Adds a one-click CSV export to the "Divergence Meter Readings" table so the data is no longer only readable in the browser.

**What it does**
- New "Export CSV" button on the Divergence Meter Readings card header (sits next to "Refresh").
- Downloads the current table as `divergence-readings-YYYY-MM-DD.csv` (RFC 4180 CSV with a UTF-8 BOM and CRLF line endings so Excel opens it cleanly).
- The export reads from `filteredReadings`, so it respects the active filters **and** the order the rows currently appear in. There is no separate sort UI yet, so "sort order" is "whatever order the user is looking at right now" — adding a column-header sort later won't require touching the export.
- Columns: `Reading,Status,Recorded By,Notes` — same shape as the on-screen table.
- Fields containing commas, double quotes, or newlines are wrapped in double quotes and internal quotes are doubled per RFC 4180.
- Button is disabled when there are no visible readings; failures surface through the existing `notyf` / Application Insights channels.

**Implementation**
- `frontend/src/utils/csvExport.js` — pure, side-effect-free CSV serializer + browser download helper. Easy to reuse for other tables later.
- `frontend/src/utils/divergenceReadingsCsv.js` — owns the column shape so the React component doesn't have to know header order or how to coerce the reading value.
- `frontend/src/pages/components/WorldlineMonitor.jsx` — adds the handler and the button, keeps the rest of the file untouched.

**Testing**
- 32 new unit tests (across 2 utility files + the existing `WorldlineMonitor.test.jsx`) covering:
  - Escape rules: commas, double quotes, CR, LF, dates, null/undefined, empty strings.
  - Header order is preserved in every row.
  - Caller-supplied row order is preserved (filter / sort passthrough).
  - Button renders, is disabled on empty data, fires the download with the right filename and body.
  - Filter state is honoured: applying a status filter narrows the exported rows.
  - Error path: serializer throwing is reported to the user, not swallowed.
- Full suite: 23 suites, 225 tests, all green.
- Coverage stays above all thresholds (statements 86.98%, branches 74.69%, functions 87.72%, lines 87.11%).
- Production build + `console.*` guard pass.

**Why I read the issue as the readings table**
The issue says "Reports can only be read in the browser" and acceptance criteria mention filters. The only table in the codebase with user-facing filters is the Divergence Meter Readings card in `WorldlineMonitor.jsx`; the experiments and worldline-history tables don't have filters. Happy to redirect the export to a different table if the intent was somewhere else — the utility code is table-agnostic and the wiring in `WorldlineMonitor.jsx` is small.